### PR TITLE
DD-111. dd-dans-deposit-to-dataverse throws exception when service is stopped

### DIFF
--- a/src/main/scala/dd2d/InboxMonitor.scala
+++ b/src/main/scala/dd2d/InboxMonitor.scala
@@ -64,7 +64,6 @@ class InboxMonitor(inbox: File, dataverse: DataverseInstance) extends DebugEnhan
 
   def stop(): Unit = {
     trace(())
-    watcher.stop()
     ingestTasks.stop()
   }
 }


### PR DESCRIPTION
Not calling `watcher.stop()` seems to resolve the problem. However, I have only tested this with an empty inbox. Please, test what happens if queue is still busy processing.