### PR TITLE
DD-106 - Include files + file metadata to dd-dans-deposit-to-dataverse

### DIFF
--- a/src/main/assembly/dist/install/dd-dans-deposit-to-dataverse.service
+++ b/src/main/assembly/dist/install/dd-dans-deposit-to-dataverse.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=EASY Sword2 To Dataverse Service
+Description=DANS Deposit To Dataverse Service
 
 [Service]
 ExecStart=/bin/java \

--- a/src/main/scala/dd2d/DdmToDataverseMapper.scala
+++ b/src/main/scala/dd2d/DdmToDataverseMapper.scala
@@ -15,7 +15,9 @@
  */
 package nl.knaw.dans.easy.dd2d
 
-import nl.knaw.dans.easy.dd2d.dataverse.json.{ CompoundField, DatasetVersion, DataverseDataset, Field, MetadataBlock, PrimitiveFieldMultipleValues, PrimitiveFieldSingleValue }
+import java.nio.file.Paths
+
+import nl.knaw.dans.easy.dd2d.dataverse.json.{ CompoundField, DatasetVersion, DataverseDataset, Field, FileMetadata, MetadataBlock, PrimitiveFieldMultipleValues, PrimitiveFieldSingleValue }
 import org.json4s.DefaultFormats
 import org.json4s.native.Serialization
 
@@ -45,6 +47,22 @@ class DdmToDataverseMapper() {
 
     /** coordinate order x, y = longitude (DCX_SPATIAL_X), latitude (DCX_SPATIAL_Y) */
     val RD_SRS_NAME = "http://www.opengis.net/def/crs/EPSG/0/28992"
+  }
+
+  def mapFilesToJson(filesXml: Node): Seq[FileMetadata] = {
+    val files = new ListBuffer[FileMetadata]
+    (filesXml \\ "file").filter(_.nonEmpty).foreach(n => {
+      val description = (n \ "description").headOption.map(_.text)
+      val directoryLabel = (n \ "@filepath").headOption.map(_.text)
+      //todo how to map permissions?
+      val restrict = Some("false")
+      files += FileMetadata(description, directoryLabel, restrict)
+    })
+    files.toList
+  }
+
+  def getDirPath(fullPath: Option[String]): Option[String] = {
+    fullPath.map(p => Paths.get(p).getParent.toString)
   }
 
   /**

--- a/src/main/scala/dd2d/DepositIngestTask.scala
+++ b/src/main/scala/dd2d/DepositIngestTask.scala
@@ -46,7 +46,7 @@ case class DepositIngestTask(deposit: Deposit, dataverse: DataverseInstance)(imp
     trace(())
     debug(s"Ingesting $deposit into Dataverse")
 
-    val validation = validateDansBag(deposit.bagDir.path)
+//    val validation = validateDansBag(deposit.bagDir.path)
 
 //    validation match {
 //      case Success(v) => {

--- a/src/main/scala/dd2d/DepositIngestTask.scala
+++ b/src/main/scala/dd2d/DepositIngestTask.scala
@@ -15,12 +15,19 @@
  */
 package nl.knaw.dans.easy.dd2d
 
+import java.nio.file.Paths
+
+import better.files.File
 import nl.knaw.dans.easy.dd2d.dataverse.DataverseInstance
 import nl.knaw.dans.easy.dd2d.queue.Task
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
-import org.json4s.Formats
+import org.json4s.native.JsonMethods._
+import org.json4s.native.Serialization
+import org.json4s.{ Formats, _ }
 
 import scala.util.{ Failure, Success, Try }
+
+case class DataverseCreateDatasetServerResponse()
 
 /**
  * Checks one deposit and then ingests it into Dataverse.
@@ -33,17 +40,28 @@ case class DepositIngestTask(deposit: Deposit, dataverse: DataverseInstance)(imp
   trace(deposit, dataverse)
 
   val mapper = new DdmToDataverseMapper()
+  //todo find a more robust solution
+  private val rootToInboxPath = "data/inbox/valid-easy-submitted/example-bag-medium/"
 
   override def run(): Try[Unit] = Try {
     trace(())
     debug(s"Ingesting $deposit into Dataverse")
 
-    // TODO: validate: is this a deposit can does it contain a bag that conforms to DANS BagIt Profile? (call easy-validate-dans-bag)
-
     deposit.tryDdm match {
       case Success(ddm) => {
         mapper.mapToJson(ddm) match {
-          case Success(json) => dataverse.dataverse("root").createDataset(json).map(_ => ())
+          case Success(json) => {
+            dataverse.dataverse("root")
+              .createDataset(json) match {
+              case Success(responseJson) => {
+                val dvId = readIdFromResponse(responseJson)
+                uploadFilesToDataset(dvId)
+              }
+              case Failure(exception) => {
+                logger.info("Creating dataset failed: " + exception.getMessage)
+              }
+            }
+          }
           case Failure(exception) => {
             logger.info("Mapping DDM to Dataverse Json failed: " + exception.getMessage)
             Failure(exception)
@@ -56,10 +74,30 @@ case class DepositIngestTask(deposit: Deposit, dataverse: DataverseInstance)(imp
       }
     }
   }
+
+  private def uploadFilesToDataset(dvId: String): Try[Unit] = {
+    deposit.tryFilesXml match {
+      case Success(filesXml) => Try {
+        mapper.mapFilesToJson(filesXml).foreach(fileMetadata => {
+          val path = rootToInboxPath + fileMetadata.directoryLabel.getOrElse("")
+
+          // Dataverse uses a "File Path" indicating which folder the file should be uploaded to within the dataset.
+          // The filepath attribute (excluding the filename) of the Bags files.xml is used for this purpose.
+          val fileMetadataUpdated = fileMetadata.copy(directoryLabel = getDirPath(fileMetadata.directoryLabel))
+          dataverse.dataverse(dvId)
+            .uploadFileToDataset(dvId, File(path), Some(Serialization.writePretty(fileMetadataUpdated)))
+        })
+      }
+      case Failure(exception) => Failure(exception)
+    }
+  }
+
+  def readIdFromResponse(responseJson: String): String = {
+    (parse(responseJson) \\ "persistentId")
+      .extract[String]
+  }
+
+  def getDirPath(fullPath: Option[String]): Option[String] = {
+    fullPath.map(p => Paths.get(p).getParent.toString)
+  }
 }
-
-
-
-
-
-

--- a/src/main/scala/dd2d/dataverse/Dataverse.scala
+++ b/src/main/scala/dd2d/dataverse/Dataverse.scala
@@ -115,6 +115,11 @@ class Dataverse(dvId: String, configuration: DataverseInstanceConfig)(implicit r
     put(s"dataverses/$dvId/metadatablocks/isRoot")(isRoot.toString.toLowerCase)
   }
 
+  def uploadFileToDataset(dvId: String, file: File, jsonMetadata: Option[String]): Try[String] = {
+    trace(())
+    postFile(s"datasets/:persistentId/add?persistentId=$dvId", file, jsonMetadata)(201)
+  }
+
   def createDataset(json: File): Try[String] = {
     trace(json)
     tryReadFileToString(json).flatMap(postJson(s"dataverses/$dvId/datasets")(201))

--- a/src/main/scala/dd2d/dataverse/HttpSupport.scala
+++ b/src/main/scala/dd2d/dataverse/HttpSupport.scala
@@ -45,8 +45,8 @@ trait HttpSupport extends DebugEnhancedLogging {
       .asBytes
   }
 
-  private def httpPostMulti(uri: URI, file: File, optJsonMetadata: Option[String] = None, headers: Map[String, String] = Map()): Try[HttpResponse[Array[Byte]]] = Try {
-    val parts = MultiPart(data = file.byteArray, name = "file", filename = file.name, mime = "application/octet-stream") +:
+  protected def httpPostMulti(uri: URI, file: File, optJsonMetadata: Option[String] = None, headers: Map[String, String] = Map()): Try[HttpResponse[Array[Byte]]] = Try {
+    val parts = MultiPart(name = "file", filename = file.name, mime = "application/octet-stream", data = file.byteArray) +:
       optJsonMetadata.map {
         json => List(MultiPart(data = json.getBytes(StandardCharsets.UTF_8), name = "jsonData", filename = "jsonData", mime = "application/json"))
       }.getOrElse(Nil)
@@ -90,7 +90,7 @@ trait HttpSupport extends DebugEnhancedLogging {
       _ = debug(s"Request URL = $uri")
       response <- http("POST", uri, body, Map("Content-Type" -> "application/json", "X-Dataverse-key" -> apiToken))
       _ <- handleResponse(response, expectedStatus: _*)
-    } yield s"Successfully POSTed: $body"
+    } yield new String(response.body)
   }
 
   protected def postText(subPath: String = null)(expectedStatus: Int*)(body: String = null): Try[String] = {

--- a/src/main/scala/dd2d/dataverse/json/package.scala
+++ b/src/main/scala/dd2d/dataverse/json/package.scala
@@ -46,4 +46,8 @@ package object json {
                            typeClass: String = "compound", // TODO: idem
                            value: List[Map[String, Field]]) extends Field
 
+  case class FileMetadata(description: Option[String] = None,
+                          directoryLabel: Option[String] = None,
+                          restrict: Option[String] = None)
+
 }

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -11,3 +11,4 @@ dataverse.connection-timeout-ms=3000
 dataverse.read-timeout-ms=3000
 # TODO: API key should be connected to user that is doing the request
 dataverse.api-key=
+easy.validator-service-url=


### PR DESCRIPTION
Fixes [DD-106](https://drivenbydata.atlassian.net/browse/DD-106)

* To test: replace the content of the dataset.xml file in `data/inbox/valid-easy-submitted/example-bag-medium/metadata/dataset.xml` with content of the attached file. This because the controlled vocabularies used in EASY ddm do no match those in Dataverse (yet).

[dataset.txt](https://github.com/DANS-KNAW/dd-dans-deposit-to-dataverse/files/5200591/dataset.txt)
* **Note: decisions  about file metadata mapping still have to be made.** 

> When adding a file to a dataset, you can optionally specify the following:
> 
>     A description of the file.
>     The “File Path” of the file, indicating which folder the file should be uploaded to within the dataset.
>     Whether or not the file is restricted.

_source: http://guides.dataverse.org/en/latest/api/native-api.html_

What to do with for example `<dcterms:created>2016-11-10</dcterms:created>` in the bags files.xml?

