### PR TITLE
DD-107 - Call easy-validate-dans-bag before mapping/ingesting deposit to Dataverse dataset

### DIFF
--- a/src/main/scala/dd2d/Configuration.scala
+++ b/src/main/scala/dd2d/Configuration.scala
@@ -24,6 +24,7 @@ import org.apache.commons.configuration.PropertiesConfiguration
 
 case class Configuration(version: String,
                          inboxDir: File,
+                         validatorServiceUrl: String,
                          dataverse: DataverseInstanceConfig,
                         )
 
@@ -43,12 +44,14 @@ object Configuration {
     new Configuration(
       version = (home / "bin" / "version").contentAsString.stripLineEnd,
       inboxDir = File(properties.getString("deposits.inbox")),
+      validatorServiceUrl = properties.getString("easy.validator-service-url"),
       dataverse = new DataverseInstanceConfig(
         connectionTimeout = properties.getInt("dataverse.connection-timeout-ms"),
         readTimeout = properties.getInt("dataverse.read-timeout-ms"),
         baseUrl = new URI(properties.getString("dataverse.base-url")),
         apiToken = properties.getString("dataverse.api-key"),
-        apiVersion = properties.getString("dataverse.api-version"))
+        apiVersion = properties.getString("dataverse.api-version")
+      )
     )
   }
 }

--- a/src/main/scala/dd2d/DansBagValidationResult.scala
+++ b/src/main/scala/dd2d/DansBagValidationResult.scala
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2020 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.s2d
+
+import org.json4s.ext.EnumNameSerializer
+import org.json4s.native.JsonMethods.parse
+import org.json4s.{ DefaultFormats, Formats }
+
+import scala.util.{ Failure, Try }
+
+/**
+ * Result object of calling the easy-validate-dans-bag service. This is the Scala representation of
+ * the JSON response object.
+ *
+ * @param bagUri          The URI of the bag to validate.
+ * @param bag             The name of the bag.
+ * @param infoPackageType `SIP` or `AIP`: the type of information package the bag was validated as.
+ * @param profileVersion  The version of the profile used in the validation.
+ * @param isCompliant     Signals whether the bag is compliant with the validated rules. If this
+ *                        field is `true`, `ruleViolations` is expected to be empty.
+ * @param ruleViolations  The rules that were violated. The violations are (rule number, violation
+ *                        details) pairs. This field is absent if `isCompliant` is `true`.
+ */
+case class DansBagValidationResult(bagUri: String,
+                                   bag: String,
+                                   infoPackageType: InformationPackageType.Value,
+                                   profileVersion: Int,
+                                   isCompliant: Boolean,
+                                   ruleViolations: Option[Seq[(String, String)]])
+object DansBagValidationResult {
+  private implicit val jsonFormats: Formats = DefaultFormats +
+    new EnumNameSerializer(InformationPackageType)
+
+  def fromJson(input: String): Try[DansBagValidationResult] = {
+    Try(parse(input).extract[DansBagValidationResult]).recoverWith { case t =>
+      Failure(new Exception(s"parse error [${ t.getClass }: ${ t.getMessage }] for: $input", t))
+    }
+  }
+}
+
+object InformationPackageType extends Enumeration {
+  type InformationPackageType = Value
+  val AIP, SIP = Value
+}

--- a/src/main/scala/dd2d/ValidateBag.scala
+++ b/src/main/scala/dd2d/ValidateBag.scala
@@ -1,0 +1,52 @@
+
+/**
+ * Copyright (C) 2020 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.s2d
+
+import java.nio.file.Path
+
+import better.files.File
+import nl.knaw.dans.easy.dd2d.Configuration
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import scalaj.http.Http
+
+import scala.util.{ Failure, Try }
+
+trait ValidateBag extends DebugEnhancedLogging {
+
+  val configuration = Configuration(File(System.getProperty("app.home")))
+  val validatorServiceUrl = configuration.validatorServiceUrl
+
+  def validateBag(bagDir: Path): Try[DansBagValidationResult] = {
+    Try {
+      val bagDirUri = bagDir.toUri.toString
+      //todo replace with uri of bagstore
+      val vmTestUri = bagDirUri.split("data/")(1)
+      val validationUrlString = s"${ validatorServiceUrl }validate?infoPackageType=SIP&uri=file:///$vmTestUri"
+      logger.info(s"Calling Dans Bag Validation Service with ${ validationUrlString }")
+      Http(s"${ validationUrlString }")
+        .timeout(connTimeoutMs = 10000, readTimeoutMs = 10000)
+        .method("POST")
+        .header("Accept", "application/json")
+        .asString
+    } flatMap {
+      case r if r.code == 200 =>
+        DansBagValidationResult.fromJson(r.body)
+      case r =>
+        Failure(new RuntimeException(s"Dans Bag Validation failed (${ r.code }): ${ r.body }"))
+    }
+  }
+}

--- a/src/main/scala/dd2d/package.scala
+++ b/src/main/scala/dd2d/package.scala
@@ -15,7 +15,15 @@
  */
 package nl.knaw.dans.easy
 
+import nl.knaw.dans.easy.dd2d.Deposit
+
 package object s2d {
 
   type DepositName = String
+
+  case class RejectedDepositException(deposit: Deposit, msg: String, cause: Throwable = null)
+    extends Exception(s"Rejected ${ deposit.dir }: $msg", cause)
+
+  case class FailedDepositException(deposit: Deposit, msg: String, cause: Throwable = null)
+    extends Exception(s"Failed ${ deposit.dir }: $msg", cause)
 }

--- a/src/test/scala/dd2d/ReadmeSpec.scala
+++ b/src/test/scala/dd2d/ReadmeSpec.scala
@@ -25,6 +25,7 @@ class ReadmeSpec extends FlatSpec with Matchers with CustomMatchers {
   private val configuration = Configuration(
     version = "my-version",
     inboxDir = null,
+    validatorServiceUrl = null,
     dataverse = null,
   )
   private val clo = new CommandLineOptions(Array[String](), configuration) {


### PR DESCRIPTION
Fixes EASY-[DD-107](https://drivenbydata.atlassian.net/browse/DD-107)

* **Note: not merge ready yet. It worked but issues with `easy-validate-dans-bag` service must be resolved first.**
see: https://drivenbydata.atlassian.net/browse/EASY-2771

