### PR TITLE
Enqueue deposits ordered by version history

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/Inbox.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/Inbox.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.easy.dd2d
 
 import better.files.{ File, FileMonitor }
+import nl.knaw.dans.easy.dd2d.queue.SortUtils.sortDeposits
 import nl.knaw.dans.easy.dd2d.dansbag.DansBagValidator
 import nl.knaw.dans.easy.dd2d.dataverse.DataverseInstance
 import nl.knaw.dans.easy.dd2d.queue.TaskQueue
@@ -39,7 +40,7 @@ class Inbox(dir: File, dansBagValidator: DansBagValidator, dataverse: DataverseI
    * @param q the TaskQueue to put the DepositIngestTasks on
    */
   def enqueue(q: TaskQueue): Unit = {
-    dirs.foreach {
+    sortDeposits(dirs).foreach {
       d => {
         debug(s"Adding $d")
         q.add(DepositIngestTask(Deposit(d), dansBagValidator, dataverse, publish = autoPublish))

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/package.scala
@@ -15,17 +15,17 @@
  */
 package nl.knaw.dans.easy.dd2d
 
-import org.joda.time.format.{ DateTimeFormat, DateTimeFormatter }
-
 import scala.xml.Node
 
 package object mapping {
+
+  case class TermAndUrl(term: String, vocabularyUrl: String)
   val XML_SCHEMA_INSTANCE_URI = "http://www.w3.org/2001/XMLSchema-instance"
 
   /**
    * Returns whether the node has an xsi:type attribute with the specified type. Note that namespace-prefix of the *value* is ignored.
    *
-   * @param node the node to examine
+   * @param node    the node to examine
    * @param xsiType the xsiType to look fore
    * @return true or false
    */
@@ -33,5 +33,4 @@ package object mapping {
     // TODO: check attribute value's namespace
     node.attribute(XML_SCHEMA_INSTANCE_URI, "type").map(_.text).map(t => t.endsWith(s":$xsiType") || t == xsiType).exists(identity)
   }
-
 }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/queue/SortUtils.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/queue/SortUtils.scala
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) 2020 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.dd2d.queue
+
+import java.io.FileInputStream
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Properties
+
+import better.files.File
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+
+object SortUtils extends DebugEnhancedLogging {
+
+  private case class DepositsSortInfo(name: String, timeStamp: LocalDateTime, isVersionOf: Option[String], deposit: File)
+  private type DepositList = List[File]
+  private type SortInfoList = List[DepositsSortInfo]
+  private type VersionMap = Map[String, List[DepositsSortInfo]]
+  private val BAG_INFO_FILE = "bag-info.txt"
+  private val IS_VERSION_OF = "Is-Version-Of"
+  private val CREATED = "Created"
+
+  /**
+   * sorts the deposit directories by dataset and per dataset by version
+   *
+   * @param dirs list of deposit directories
+   * @return the sorted list of deposit directories
+   */
+  def sortDeposits(dirs: DepositList): DepositList = {
+    val sortInfoList = dirs.map(d => getDepositSortInfo(d))
+    val groupedDeposits = groupVersions(sortInfoList)
+    sortVersions(groupedDeposits)
+  }
+
+  /**
+   * creates a DepositsSortInfo object that contains necessary sorting information
+   *
+   * @param deposit the deposit directory
+   * @return DepositsSortInfo
+   */
+  private def getDepositSortInfo(deposit: File): DepositsSortInfo = {
+    val bagInfoFile = deposit.list(_.isRegularFile, 2).filter(_.name == BAG_INFO_FILE).toList.head
+    val properties = new Properties()
+    properties.load(new FileInputStream(bagInfoFile.pathAsString));
+    val timeStamp = parseTimestamp(properties.getProperty(CREATED))
+    val isVersionOf: Option[String] = properties.getProperty(IS_VERSION_OF) match {
+      case null => None
+      case uuid: String => Some(uuid)
+    }
+    DepositsSortInfo(deposit.name, timeStamp, isVersionOf, deposit)
+  }
+
+  private def groupVersions(depositsSortInfoList: SortInfoList): VersionMap = {
+    val firstVersions = depositsSortInfoList
+      .filter(_.isVersionOf.isEmpty)
+      .map(v => v.name -> List(v)).toMap
+
+    val laterVersions =
+      depositsSortInfoList
+        .filter(_.isVersionOf.isDefined)
+        .groupBy(_.isVersionOf.get)
+
+    val laterVersionsUpdated = removeDatasetsWithoutFirstVersion(firstVersions, laterVersions)
+
+    (firstVersions.keySet ++ laterVersionsUpdated.keySet)
+      .map(k => k -> (firstVersions(k) ++ laterVersionsUpdated(k)))
+      .toMap
+  }
+
+  private def sortVersions(groupedDeposits: VersionMap): DepositList = {
+    groupedDeposits.mapValues(k => sortByTimestamp(k))
+      .flatMap(_._2)
+      .map(_.deposit)
+      .toList
+  }
+
+  private def removeDatasetsWithoutFirstVersion(firstVersions: VersionMap, laterVersions: VersionMap): VersionMap = {
+    val datasetsWithoutFirstVersions = for (k <- laterVersions if !firstVersions.keySet.contains(k._1)) yield k
+    datasetsWithoutFirstVersions.foreach(v => logger.error(s"No first version was found for dataset ${ v._1 }. The dataset was not imported into Dataverse"))
+    val correctVersions = for (k <- laterVersions if firstVersions.keySet.contains(k._1)) yield k
+    correctVersions
+  }
+
+  private def parseTimestamp(timestampString: String): LocalDateTime = {
+    LocalDateTime.parse(timestampString, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+  }
+
+  private def sortByTimestamp(sortInfoList: SortInfoList): SortInfoList = {
+    sortInfoList.sortBy(_.timeStamp)
+  }
+
+  implicit def ordered: Ordering[LocalDateTime] = (x: LocalDateTime, y: LocalDateTime) => x compareTo y
+}

--- a/src/test/resources/unordered-stub-deposits/deposit1/bag-info.txt
+++ b/src/test/resources/unordered-stub-deposits/deposit1/bag-info.txt
@@ -1,0 +1,5 @@
+EASY-User-Account: user001
+Created: 2020-11-17T09:24:06.418+01:00
+Payload-Oxum: 20.2
+Bagging-Date: 2020-11-17
+Bag-Size: 0 KB

--- a/src/test/resources/unordered-stub-deposits/deposit1_a/bag-info.txt
+++ b/src/test/resources/unordered-stub-deposits/deposit1_a/bag-info.txt
@@ -1,0 +1,6 @@
+EASY-User-Account: user001
+Created: 2020-11-17T09:25:06.418+01:00
+Is-Version-Of: deposit1
+Payload-Oxum: 20.2
+Bagging-Date: 2020-11-17
+Bag-Size: 0 KB

--- a/src/test/resources/unordered-stub-deposits/deposit1_b/bag-info.txt
+++ b/src/test/resources/unordered-stub-deposits/deposit1_b/bag-info.txt
@@ -1,0 +1,6 @@
+EASY-User-Account: user001
+Created: 2020-11-17T09:26:06.418+01:00
+Is-Version-Of: deposit1
+Payload-Oxum: 20.2
+Bagging-Date: 2020-11-17
+Bag-Size: 0 KB

--- a/src/test/resources/unordered-stub-deposits/deposit2/bag-info.txt
+++ b/src/test/resources/unordered-stub-deposits/deposit2/bag-info.txt
@@ -1,0 +1,5 @@
+EASY-User-Account: user001
+Created: 2020-11-17T09:26:06.418+01:00
+Payload-Oxum: 20.2
+Bagging-Date: 2020-11-17
+Bag-Size: 0 KB

--- a/src/test/resources/unordered-stub-deposits/deposit2_a/bag-info.txt
+++ b/src/test/resources/unordered-stub-deposits/deposit2_a/bag-info.txt
@@ -1,0 +1,6 @@
+EASY-User-Account: user001
+Created: 2020-11-17T09:27:06.418+01:00
+Is-Version-Of: deposit2
+Payload-Oxum: 20.2
+Bagging-Date: 2020-11-17
+Bag-Size: 0 KB

--- a/src/test/resources/unordered-stub-deposits/deposit3/bag-info.txt
+++ b/src/test/resources/unordered-stub-deposits/deposit3/bag-info.txt
@@ -1,0 +1,5 @@
+EASY-User-Account: user001
+Created: 2020-11-17T09:24:10.418+01:00
+Payload-Oxum: 20.2
+Bagging-Date: 2020-11-17
+Bag-Size: 0 KB

--- a/src/test/resources/unordered-stub-deposits/deposit3_a/bag-info.txt
+++ b/src/test/resources/unordered-stub-deposits/deposit3_a/bag-info.txt
@@ -1,0 +1,6 @@
+EASY-User-Account: user001
+Created: 2020-11-17T09:25:06.418+01:00
+Payload-Oxum: 20.2
+Is-Version-Of: deposit3
+Bagging-Date: 2020-11-17
+Bag-Size: 0 KB

--- a/src/test/resources/unordered-stub-deposits/deposit3_b/bag-info.txt
+++ b/src/test/resources/unordered-stub-deposits/deposit3_b/bag-info.txt
@@ -1,0 +1,6 @@
+EASY-User-Account: user001
+Created: 2020-11-17T09:26:06.418+01:00
+Payload-Oxum: 20.2
+Is-Version-Of: deposit3
+Bagging-Date: 2020-11-17
+Bag-Size: 0 KB

--- a/src/test/resources/unordered-stub-deposits/deposit_without_first_version/bag-info.txt
+++ b/src/test/resources/unordered-stub-deposits/deposit_without_first_version/bag-info.txt
@@ -1,0 +1,6 @@
+EASY-User-Account: user001
+Created: 2020-11-17T09:24:06.418+01:00
+Is-Version-Of: deposit_not_found
+Payload-Oxum: 20.2
+Bagging-Date: 2020-11-17
+Bag-Size: 0 KB

--- a/src/test/scala/nl.knaw.dans.easy.dd2d/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.dd2d/TestSupportFixture.scala
@@ -22,5 +22,6 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with CustomM
 
   lazy val testDirValid: File = File("src/test/resources/examples")
   lazy val testDirNonValid: File = File("src/test/resources/no-deposit")
+  lazy val testDirUnorderedDeposits = File("src/test/resources/unordered-stub-deposits")
 }
 

--- a/src/test/scala/nl.knaw.dans.easy.dd2d/queue/DepositDirListSortSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.dd2d/queue/DepositDirListSortSpec.scala
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2020 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.dd2d.queue
+
+import nl.knaw.dans.easy.dd2d.TestSupportFixture
+import org.scalatest.Matchers
+
+class DepositDirListSortSpec extends TestSupportFixture with Matchers {
+
+  val depositDirs = testDirUnorderedDeposits.list(_.isDirectory, maxDepth = 1).filterNot(_ == testDirUnorderedDeposits).toList
+  val DATASETVERSIONS_WITHOUT_FIRST_VERSION = 1
+
+  "The result" should "be a list with size" + (depositDirs.size - DATASETVERSIONS_WITHOUT_FIRST_VERSION) in {
+    val result = SortUtils.sortDeposits(depositDirs)
+    result should have size depositDirs.size - DATASETVERSIONS_WITHOUT_FIRST_VERSION
+  }
+
+  it should "be a correctly ordered list" in {
+    val result = SortUtils.sortDeposits(depositDirs)
+    result.map(_.name) should be(List("deposit2", "deposit2_a", "deposit3", "deposit3_a", "deposit3_b", "deposit1", "deposit1_a", "deposit1_b"))
+  }
+}


### PR DESCRIPTION
Fixes [DD-183](https://drivenbydata.atlassian.net/browse/DD-183) - Enqueue deposits ordered by version history
Note: this sorting applies only to the use of the `import` subcommand (The inbox is already filled with deposits).
