### PR TITLE
Draft. Refactoring smoke test.

### DIFF
--- a/src/test/scala/nl.knaw.dans.easy.dd2d/DdmToDataverseMapperSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.dd2d/DdmToDataverseMapperSpec.scala
@@ -15,14 +15,16 @@
  */
 package nl.knaw.dans.easy.dd2d
 
-import nl.knaw.dans.easy.dd2d.dataverse.json.{ CompoundField, DatasetVersion, DataverseDataset, MetadataBlock, PrimitiveFieldMultipleValues, PrimitiveFieldSingleValue, createPrimitiveFieldSingleValue }
+import nl.knaw.dans.easy.dd2d.dataverse.json.{ CompoundField, DatasetVersion, DataverseDataset, MetadataBlock, createPrimitiveFieldSingleValue }
 import nl.knaw.dans.easy.dd2d.mapping.{ BlockBasicInformation, BlockCitation, BlockTemporalAndSpatial }
-import org.json4s.DefaultFormats
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import org.json4s.JsonAST.JString
 import org.json4s.native.Serialization
+import org.json4s.{ DefaultFormats, Extraction, JArray, JBool, JValue }
 
 import scala.util.Success
 
-class DdmToDataverseMapperSpec extends TestSupportFixture with BlockCitation with BlockBasicInformation with BlockTemporalAndSpatial {
+class DdmToDataverseMapperSpec extends TestSupportFixture with DebugEnhancedLogging with BlockCitation with BlockBasicInformation with BlockTemporalAndSpatial {
 
   implicit val format: DefaultFormats.type = DefaultFormats
   private val mapper = new DdmToDataverseMapper()
@@ -123,5 +125,142 @@ class DdmToDataverseMapperSpec extends TestSupportFixture with BlockCitation wit
             "authorAffiliation" -> createPrimitiveFieldSingleValue("authorAffiliation", "Uitvindersgilde")
           ))
     }
+  }
+
+  it should "map the whole ddm correctly to JSON objects" in {
+    val ddm =
+      <ddm:DDM xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" >
+          <ddm:profile>
+              <dc:title>A title</dc:title>
+              <dc:description>Description</dc:description>
+              <dc:description>Description 2</dc:description>
+              <dcx-dai:creatorDetails>
+                  <dcx-dai:author>
+                      <dcx-dai:titles>Dr</dcx-dai:titles>
+                      <dcx-dai:initials>A</dcx-dai:initials>
+                      <dcx-dai:insertions>van</dcx-dai:insertions>
+                      <dcx-dai:surname>Helsing</dcx-dai:surname>
+                      <dcx-dai:organization>
+                          <dcx-dai:name xml:lang="en">Anti-Vampire League</dcx-dai:name>
+                      </dcx-dai:organization>
+                  </dcx-dai:author>
+              </dcx-dai:creatorDetails>
+              <dcx-dai:creatorDetails>
+                  <dcx-dai:author>
+                      <dcx-dai:titles>Professor</dcx-dai:titles>
+                      <dcx-dai:initials>T</dcx-dai:initials>
+                      <dcx-dai:insertions></dcx-dai:insertions>
+                      <dcx-dai:surname>Zonnebloem</dcx-dai:surname>
+                      <dcx-dai:organization>
+                          <dcx-dai:name xml:lang="en">Uitvindersgilde</dcx-dai:name>
+                      </dcx-dai:organization>
+                  </dcx-dai:author>
+              </dcx-dai:creatorDetails>
+              <dcx-dai:creatorDetails>
+                  <dcx-dai:organization>
+                      <dcx-dai:name xml:lang="en">Anti-Vampire League</dcx-dai:name>
+                      <dcx-dai:role xml:lang="en">DataCurator</dcx-dai:role>
+                  </dcx-dai:organization>
+              </dcx-dai:creatorDetails>
+              <ddm:created>2015-09-09</ddm:created>
+              <ddm:available>2016-09-08</ddm:available>
+              <ddm:audience>D16</ddm:audience>
+              <ddm:audience>D1630</ddm:audience>
+              <ddm:accessRights>NO_ACCESS</ddm:accessRights>
+          </ddm:profile>
+          <ddm:dcmiMetadata>
+              <dcterms:isFormatOf>https://test.example/1</dcterms:isFormatOf>
+              <dcterms:language xsi:type="ISO639-2">eng</dcterms:language>
+              <dcterms:language xsi:type="ISO639-2">nld</dcterms:language>
+              <dcterms:language>sui</dcterms:language>
+              <dcterms:alternative>Alternative title</dcterms:alternative>
+              <dcterms:source>source 1</dcterms:source>
+              <dcterms:source>source 2</dcterms:source>
+              <dcx-dai:contributorDetails>
+                  <dcx-dai:author>
+                      <dcx-dai:titles>Advocaat</dcx-dai:titles>
+                      <dcx-dai:initials>J</dcx-dai:initials>
+                      <dcx-dai:insertions></dcx-dai:insertions>
+                      <dcx-dai:surname>Harker</dcx-dai:surname>
+                      <dcx-dai:role xml:lang="en">Related Person</dcx-dai:role>
+                  </dcx-dai:author>
+              </dcx-dai:contributorDetails>
+              <dcx-dai:contributorDetails>
+                  <dcx-dai:organization>
+                      <dcx-dai:name xml:lang="en">Advocatenkantoor Harker</dcx-dai:name>
+                      <dcx-dai:role xml:lang="en">RightsHolder</dcx-dai:role>
+                  </dcx-dai:organization>
+              </dcx-dai:contributorDetails>
+              <dcterms:hasVersion scheme="DOI">https://doi.org/10.17632/5x6xt4zhws.3</dcterms:hasVersion>
+              <dcterms:references href="https://a-v.l.w.com">Anti-Vampire League website</dcterms:references>
+              <dcterms:dateAccepted>2016-09-08</dcterms:dateAccepted>
+              <dcterms:modified xsi:type="W3CDTF">2017-01-02</dcterms:modified>
+              <dcterms:identifier xsi:type="ARCHIS-ZAAK-IDENTIFICATIE">1234567890</dcterms:identifier>
+              <dcx-gml:spatial>
+                  <Point xmlns="http://www.opengis.net/gml">
+                      <pos>
+                          52.08113 4.34510
+                      </pos>
+                  </Point>
+              </dcx-gml:spatial>
+                  <dcx-gml:spatial>
+                      <boundedBy xmlns="http://www.opengis.net/gml">
+                          <Envelope srsName="urn:ogc:def:crs:EPSG::28992">
+                              <lowerCorner>91232.015554 436172.485680</lowerCorner>
+                              <upperCorner>121811.885272 486890.494251</upperCorner>
+                          </Envelope>
+                      </boundedBy>
+                  </dcx-gml:spatial>
+          </ddm:dcmiMetadata>
+      </ddm:DDM>
+
+    val metadataBlocks = mapper.toDataverseDataset(ddm).get.datasetVersion.metadataBlocks
+    val citationJson = Extraction.decompose(metadataBlocks("citation"))
+    debug(Serialization.writePretty(citationJson))
+
+    (citationJson \ "displayName") shouldBe JString("Citation Metadata")
+
+    /*
+     * Expected:
+     * {
+     *    "typeName":"title",
+     *    "multiple":false,
+     *    "typeClass":"primitive",
+     *    "value":"A title"
+     * }
+     */
+    val titles = (citationJson \ "fields").filter(_ \ "typeName" == JString("title"))
+    titles should have length (1)
+    val title = titles.head
+    title \ "multiple" shouldBe JBool(false)
+    title \ "typeClass" shouldBe JString("primitive")
+    title \ "value" shouldBe JString("A title")
+
+    /*
+     * Expected:
+     * {
+     *    "typeName":"otherId",
+     *    "multiple":true,
+     *    "typeClass":"compound",
+     *    "value":[
+     *        {
+     *          "otherIdValue":{
+     *              "typeName":"otherIdValue",
+     *              "multiple":false,
+     *              "typeClass":"primitive",
+     *              "value":"https://test.example/1"
+     *           }
+     *        }
+     *     ]
+     * }
+     */
+    val otherIds = ((citationJson \ "fields")).filter(_ \ "typeName" == JString("otherId"))
+    otherIds should have length (1)
+    val otherId = otherIds.head
+    otherId \ "multiple" shouldBe JBool(true)
+    otherId \ "typeClass" shouldBe JString("compound")
+    val otherIdValue = (otherId \ "value")
+    otherIdValue shouldBe a[JArray]
+    otherIdValue.asInstanceOf[JArray].values should have length(1)
   }
 }


### PR DESCRIPTION
# Description of changes
I removed @vesaakerman's large test during a code clean-up because it proved difficult to maintain and I was in a hurry to get my clean-up doen. This PR is an attempt to restore it while addressing the things that made Vesa's test hard to read.

First of all, I think this test should not try to verify too much. The details are better tested in smaller scoped tests. The goal of the large test is to see if a larger document doesn't reveal other types of problems that never show up in the minimal examples used in the detailed unit tests.

The basic plan is to map a larger DDM (copied the one that Vesa used) and:

1. Check that it succeeds
2. Check a *limited* number of mappings. (I am thinking in the order of 3-8 checks).

I am now trying to use the embedded XPath style queries to select the output to be checked, but it is not so easy to write. We might after all want to use the JsonPathSupport. 

Setting this PR to draft, so others can have a look at it. 

# How to test
* Run the unit test.

# Related PRs 
* https://github.com/DANS-KNAW/dd-dans-deposit-to-dataverse/pull/16

# Notify
@DANS-KNAW/dataversedans
