### PR TITLE
Fixed deposit sorting bug

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositSorter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositSorter.scala
@@ -53,7 +53,7 @@ class DepositSorter extends TaskSorter[Deposit] with DebugEnhancedLogging {
       case null => None
       case uuid: String => Some(uuid)
     }
-    DepositsSortInfo(s"urn:uuid:${depositIngestTask.deposit.dir.name}", timeStamp, isVersionOf, depositIngestTask)
+    DepositsSortInfo(s"urn:uuid:${ depositIngestTask.deposit.dir.name }", timeStamp, isVersionOf, depositIngestTask)
   }
 
   private def getDepositSequences(depositsSortInfoList: List[DepositsSortInfo]): baseIdToAllVersions = {
@@ -69,7 +69,12 @@ class DepositSorter extends TaskSorter[Deposit] with DebugEnhancedLogging {
     val laterVersionsUpdated = removeDatasetsWithoutFirstVersion(firstVersions, laterVersions)
 
     (firstVersions.keySet ++ laterVersionsUpdated.keySet)
-      .map(k => k -> (firstVersions(k) ++ laterVersionsUpdated(k)))
+      .map(k => {
+        if (laterVersionsUpdated.contains(k))
+          k -> (firstVersions(k) ++ laterVersionsUpdated(k))
+        else
+          k -> firstVersions(k)
+      })
       .toMap
   }
 


### PR DESCRIPTION
Fixes [DD-269](https://drivenbydata.atlassian.net/browse/DD-269)
Note: the problem wasn't about related pairs of deposits but about a `NoSuchElementException` being thrown for a non-existent key.

# Description of changes
Added check on existence of key in Map

# How to test
1. Deploy module on dd-dtap
2. import dataset attached in Jira issue (https://drivenbydata.atlassian.net/browse/DD-269)


# Related PRs 
(Add links)
* 

# Notify
@DANS-KNAW/dataversedans
