### PR TITLE
Refactoring Controlled Vocabulary classes

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Audience.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Audience.scala
@@ -17,7 +17,7 @@ package nl.knaw.dans.easy.dd2d.mapping
 
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
-import scala.xml.{ Elem, Node, XML }
+import scala.xml.{ Elem, Node }
 
 /**
  * ddm:audience element with a NARCIS classification code in it.
@@ -43,37 +43,37 @@ object Audience extends BlockBasicInformation with DebugEnhancedLogging {
   /**
    * Creates a Map with Subject CV fields for a Compound Field
    *
-   * @param node the audience element
+   * @param node                 the audience element
    * @param narcisClassification the Narcis classification
    * @return A JsonObject with Subject CV fields
    */
   def toBasicInformationBlockSubjectCv(node: Node, narcisClassification: Elem): Option[JsonObject] = {
-    val termAndUrl = getTermAndUrl(node, narcisClassification)
-    termAndUrl.term match {
-      case "" =>
-        logger.error(s"Invalid controlled vocabulary term for 'Subject': $termAndUrl'")
-        None
-      case _ =>
+    getTermAndUrl(node, narcisClassification)
+      .map(termAndUrl => {
         val m = FieldMap()
         m.addPrimitiveField(SUBJECT_CV_VALUE, termAndUrl.term)
         m.addPrimitiveField(SUBJECT_CV_VOCABULARY, SUBJECT_NARCIS_CLASSIFICATION)
         m.addPrimitiveField(SUBJECT_CV_VOCABULARY_URI, termAndUrl.url)
-        Some(m.toJsonObject)
-    }
+        m.toJsonObject
+      }).doIfNone(() => logger.error(s"Invalid controlled vocabulary term for 'Subject': ${ node.text }"))
   }
 
   /**
    * Gets term and url from the NARCIS classification
    *
-   * @param node the audience element
+   * @param node                 the audience element
    * @param narcisClassification the Narcis classification
-   * @return the Dataverse subject term and url
+   * @return the Dataverse subject term and url or None
    */
-  private def getTermAndUrl(node: Node, narcisClassification: Elem): TermAndUrl = {
-    val element = narcisClassification.child.filter(_.attributes.exists(_.value.text contains node.text))
-    val term = element.headOption.flatMap(_.child.find(_.label == "prefLabel")).map(_.text).getOrElse("")
-    val url = element.headOption.flatMap(_.attributes.value.headOption).getOrElse(SUBJECT_NARCIS_CLASSIFICATION_URL).toString
-    TermAndUrl(term, url)
+  private def getTermAndUrl(node: Node, narcisClassification: Elem): Option[TermAndUrl] = {
+    narcisClassification
+      .child
+      .find(_.attributes.exists(_.value.text contains node.text))
+      .map(description => {
+        val term = description.headOption.flatMap(_.child.find(_.label == "prefLabel")).map(_.text).getOrElse("")
+        val url = description.headOption.flatMap(_.attributes.value.headOption).getOrElse(SUBJECT_NARCIS_CLASSIFICATION_URL).toString
+        TermAndUrl(term, url)
+      })
   }
 
   /**

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Format.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Format.scala
@@ -21,39 +21,34 @@ import scala.xml.Node
 
 object Format extends BlockContentTypeAndFileFormat with DebugEnhancedLogging {
 
-  val imtFormats = Map(
-    "application/postscript" -> "application/postscript",
-    "application/rtf" -> "application/rtf",
-    "application/pdf" -> "application/pdf",
-    "application/msword" -> "application/msword",
-    "text/plain" -> "text/plain",
-    "text/html" -> "text/html",
-    "text/sgml" -> "text/sgml",
-    "text/xml" -> "text/xml",
-    "image/jpeg" -> "image/jpeg",
-    "image/gif" -> "image/gif",
-    "image/tiff" -> "image/tiff",
-    "video/quicktime" -> "video/quicktime",
-    "video/mpeg1" -> "video/mpeg1"
+  val imtFormats = List(
+    "application/postscript",
+    "application/rtf",
+    "application/pdf",
+    "application/msword",
+    "text/plain",
+    "text/html",
+    "text/sgml",
+    "text/xml",
+    "image/jpeg",
+    "image/gif",
+    "image/tiff",
+    "video/quicktime",
+    "video/mpeg1"
   )
 
   def toContentTypeAndFileFormatBlockFormat(node: Node): Option[JsonObject] = {
-    // TODO: properly use Option[String] here and use Option.map instead of match construct
-    val contentFormat = getContentFormat(node)
-    contentFormat match {
-      case "" =>
-        logger.error(s"Invalid controlled vocabulary term for 'Format (Media Type)': '$contentFormat'")
-        None
-      case _ =>
-        val m = FieldMap()
-        m.addPrimitiveField(FORMAT_CV_VALUE, contentFormat)
-        m.addPrimitiveField(FORMAT_CV_VOCABULARY, DCMI_FORMAT)
-        m.addPrimitiveField(FORMAT_CV_VOCABUALRY_URL, DCMI_FORMAT_BASE_URL + contentFormat)
-        Some(m.toJsonObject)
+    val contentFormat = node.text
+    if (imtFormats.contains(contentFormat)) {
+      val m = FieldMap()
+      m.addPrimitiveField(FORMAT_CV_VALUE, node.text)
+      m.addPrimitiveField(FORMAT_CV_VOCABULARY, DCMI_FORMAT)
+      m.addPrimitiveField(FORMAT_CV_VOCABUALRY_URL, DCMI_FORMAT_BASE_URL + contentFormat)
+      Some(m.toJsonObject)
     }
-  }
-
-  def getContentFormat(node: Node): String = {
-    imtFormats.getOrElse(node.text, "")
+    else {
+      logger.error(s"Invalid controlled vocabulary term for 'Format (Media Type)': '$contentFormat'")
+      None
+    }
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Language.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Language.scala
@@ -72,7 +72,7 @@ object Language extends BlockBasicInformation with DebugEnhancedLogging {
   }
 
   def getXmlLangAttribute(ddm: Node): String = {
-    (ddm \\ "title").headOption.filter(_.attributes.nonEmpty).map(_.attributes).filter(_.key.contains("lang")).map(_.value).getOrElse("").toString
+    (ddm \\ "_").filter(_.attributes.nonEmpty).map(_.attributes).find(_.key.contains("lang")).map(_.value).getOrElse("").toString
   }
 
   def toCitationBlockLanguage(node: Node): Option[String] = {

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Language.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Language.scala
@@ -40,18 +40,15 @@ object Language extends BlockBasicInformation with DebugEnhancedLogging {
   )
 
   def toBasicInformationBlockLanguageOfFiles(node: Node): Option[JsonObject] = {
-    val isoLanguage = getISOLanguage(node)
-    isoLanguage match {
-      case "" =>
-        logger.error(s"Invalid controlled vocabulary term for 'Language of Files': '$isoLanguage'. Ignoring.")
-        None
-      case _ =>
+
+    iso639_2ToDataverse.get(node.text)
+      .map(isoLanguage => {
         val m = FieldMap()
         m.addPrimitiveField(LANGUAGE_OF_FILES_CV_VALUE, isoLanguage)
         m.addPrimitiveField(LANGUAGE_OF_FILES_CV_VOCABULARY, LANGUAGE_OF_FILES_CV_VOCABULARY_NAME)
         m.addPrimitiveField(LANGUAGE_OF_FILES_CV_VOCABULART_URL, LANGUAGE_CV_ISO_639_2_URL + node.text)
-        Some(m.toJsonObject)
-    }
+        m.toJsonObject
+      })
   }
 
   def toBasicInformationLanguageOfMetadata(node: Node): Option[JsonObject] = {
@@ -59,26 +56,19 @@ object Language extends BlockBasicInformation with DebugEnhancedLogging {
     val xmlLangAttribute = getXmlLangAttribute(node)
     //ISO 639-2: three letter country codes. Only these are resolvable when used in term url.
     val iso639_2LangAttribute = iso639_1ToIso639_2.getOrElse(xmlLangAttribute, "")
-    val isoLanguage = iso639_2ToDataverse.getOrElse(iso639_2LangAttribute, "")
-    isoLanguage match {
-      case "" =>
-        logger.error(s"Invalid controlled vocabulary term for 'Language of Metadata'")
-        None
-      case _ =>
+
+    iso639_2ToDataverse.get(iso639_2LangAttribute)
+      .map(isoLanguage => {
         val m = FieldMap()
         m.addPrimitiveField(LANGUAGE_OF_METADATA_CV_VALUE, isoLanguage)
         m.addPrimitiveField(LANGUAGE_OF_METADATA_CV_VOCABULARY, LANGUAGE_OF_FILES_CV_VOCABULARY_NAME)
         m.addPrimitiveField(LANGUAGE_OF_METADATA_CV_VOCABULART_URL, LANGUAGE_CV_ISO_639_2_URL + iso639_2LangAttribute)
-        Some(m.toJsonObject)
-    }
+        m.toJsonObject
+      }).doIfNone(() => logger.error(s"Invalid controlled vocabulary term for 'Language of Metadata'"))
   }
 
   def isISOLanguage(node: Node): Boolean = {
     hasXsiType(node, "ISO639-2")
-  }
-
-  def getISOLanguage(node: Node): String = {
-    iso639_2ToDataverse.getOrElse(node.text, "")
   }
 
   def getXmlLangAttribute(ddm: Node): String = {

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/SubjectAbr.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/SubjectAbr.scala
@@ -121,11 +121,11 @@ object SubjectAbr extends BlockArchaeologySpecific with DebugEnhancedLogging {
   def toSubjectAbrObject(node: Node): Option[JsonObject] = {
     ariadneSubjectToDataversename
       .get(node.text)
-      .map(_ => {
+      .map(item => {
         val m = FieldMap()
-        m.addPrimitiveField(ABR_SUBJECT_VALUE, ariadneSubjectToDataversename.get(node.text).map(_.term).getOrElse(""))
+        m.addPrimitiveField(ABR_SUBJECT_VALUE, item.term)
         m.addPrimitiveField(ABR_SUBJECT_VOCABULARY, "ABR-complex")
-        m.addPrimitiveField(ABR_SUBJECT_VOCABULARY_URL, ariadneSubjectToDataversename.get(node.text).map(_.url).getOrElse(ABR_BASE_URL))
+        m.addPrimitiveField(ABR_SUBJECT_VOCABULARY_URL, item.url)
         m.toJsonObject
       }).doIfNone(() => logger.error(s"Invalid controlled vocabulary term for 'Subject (ABR Complex)': ${ node.text }"))
   }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/SubjectAbr.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/SubjectAbr.scala
@@ -119,18 +119,15 @@ object SubjectAbr extends BlockArchaeologySpecific with DebugEnhancedLogging {
   )
 
   def toSubjectAbrObject(node: Node): Option[JsonObject] = {
-    val abrSubject = ariadneSubjectToDataversename.get(node.text).map(_.term).getOrElse("")
-    abrSubject match {
-      case "" =>
-        logger.error(s"Invalid controlled vocabulary term for 'Subject (ABR Complex)': '$abrSubject'")
-        None
-      case _ =>
+    ariadneSubjectToDataversename
+      .get(node.text)
+      .map(_ => {
         val m = FieldMap()
-        m.addPrimitiveField(ABR_SUBJECT_VALUE, abrSubject)
+        m.addPrimitiveField(ABR_SUBJECT_VALUE, ariadneSubjectToDataversename.get(node.text).map(_.term).getOrElse(""))
         m.addPrimitiveField(ABR_SUBJECT_VOCABULARY, "ABR-complex")
         m.addPrimitiveField(ABR_SUBJECT_VOCABULARY_URL, ariadneSubjectToDataversename.get(node.text).map(_.url).getOrElse(ABR_BASE_URL))
-        Some(m.toJsonObject)
-    }
+        m.toJsonObject
+      }).doIfNone(() => logger.error(s"Invalid controlled vocabulary term for 'Subject (ABR Complex)': ${ node.text }"))
   }
 
   def isNotEmpty(node: Node): Boolean = {

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/TemporalAbr.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/TemporalAbr.scala
@@ -79,18 +79,15 @@ object TemporalAbr extends BlockArchaeologySpecific with DebugEnhancedLogging {
   )
 
   def toTemporalAbr(node: Node): Option[JsonObject] = {
-    val abrTemporal = ariadneTemporalToDataversename.get(node.text).map(_.term).getOrElse("")
-    abrTemporal match {
-      case "" =>
-        logger.error(s"Invalid controlled vocabulary term for 'Temporal (ABR Period)': $abrTemporal")
-        None
-      case _ =>
+    ariadneTemporalToDataversename
+      .get(node.text)
+      .map(_ => {
         val m = FieldMap()
         m.addPrimitiveField(ABR_PERIOD_VALUE, ariadneTemporalToDataversename.get(node.text).map(_.term).getOrElse("Other"))
         m.addPrimitiveField(ABR_PERIOD_VOCABULARY, "ABR-periode")
         m.addPrimitiveField(ABR_PERIOD_VOCABULARY_URL, ariadneTemporalToDataversename.get(node.text).map(_.url).getOrElse(ABR_BASE_URL))
-        Some(m.toJsonObject)
-    }
+        m.toJsonObject
+      }).doIfNone(() => logger.error(s"Invalid controlled vocabulary term for 'Temporal (ABR Period)': ${ node.text }"))
   }
 
   def isNotEmpty(node: Node): Boolean = {

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/TemporalAbr.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/TemporalAbr.scala
@@ -81,11 +81,11 @@ object TemporalAbr extends BlockArchaeologySpecific with DebugEnhancedLogging {
   def toTemporalAbr(node: Node): Option[JsonObject] = {
     ariadneTemporalToDataversename
       .get(node.text)
-      .map(_ => {
+      .map(item => {
         val m = FieldMap()
-        m.addPrimitiveField(ABR_PERIOD_VALUE, ariadneTemporalToDataversename.get(node.text).map(_.term).getOrElse("Other"))
+        m.addPrimitiveField(ABR_PERIOD_VALUE, item.term)
         m.addPrimitiveField(ABR_PERIOD_VOCABULARY, "ABR-periode")
-        m.addPrimitiveField(ABR_PERIOD_VOCABULARY_URL, ariadneTemporalToDataversename.get(node.text).map(_.url).getOrElse(ABR_BASE_URL))
+        m.addPrimitiveField(ABR_PERIOD_VOCABULARY_URL, item.url)
         m.toJsonObject
       }).doIfNone(() => logger.error(s"Invalid controlled vocabulary term for 'Temporal (ABR Period)': ${ node.text }"))
   }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Type.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Type.scala
@@ -21,37 +21,33 @@ import scala.xml.Node
 
 object Type extends BlockContentTypeAndFileFormat with DebugEnhancedLogging {
   //todo what values are allowed in ingest?
-  val dcmiTypes = Map(
-    "Collection" -> "Collection",
-    "Dataset" -> "Dataset",
-    "Event" -> "Event",
-    "Image" -> "Image",
-    "Interactive resource" -> "Interactive resource",
-    "Moving image" -> "Moving image",
-    "Physical object" -> "Physical object",
-    "Service" -> "Service",
-    "Software" -> "Software",
-    "Sound" -> "Sound",
-    "Still image" -> "Still image",
-    "Text" -> "Text"
+  val dcmiTypes = List(
+    "Collection",
+    "Dataset",
+    "Event",
+    "Image",
+    "Interactive resource",
+    "Moving image",
+    "Physical object",
+    "Service",
+    "Software",
+    "Sound",
+    "Still image",
+    "Text"
   )
 
   def toContentTypeAndFileFormatBlockType(node: Node): Option[JsonObject] = {
-    val contentType = getContentType(node)
-    contentType match {
-      case "" =>
-        logger.error(s"Invalid controlled vocabulary term for 'Content Type': '$contentType'")
-        None
-      case _ =>
-        val m = FieldMap()
-        m.addPrimitiveField(CONTENT_TYPE_CV_VALUE, contentType)
-        m.addPrimitiveField(CONTENT_TYPE_CV_VOCABULARY, DCMI_TYPE)
-        m.addPrimitiveField(CONTENT_TYPE_CV_VOCABULARY_URL, DCMI_TYPE_BASE_URL + contentType)
-        Some(m.toJsonObject)
+    val contentType = node.text
+    if (dcmiTypes.contains(contentType)) {
+      val m = FieldMap()
+      m.addPrimitiveField(CONTENT_TYPE_CV_VALUE, contentType)
+      m.addPrimitiveField(CONTENT_TYPE_CV_VOCABULARY, DCMI_TYPE)
+      m.addPrimitiveField(CONTENT_TYPE_CV_VOCABULARY_URL, DCMI_TYPE_BASE_URL + contentType)
+      Some(m.toJsonObject)
     }
-  }
-
-  def getContentType(node: Node): String = {
-    dcmiTypes.getOrElse(node.text, "")
+    else {
+      logger.error(s"Invalid controlled vocabulary term for 'Content Type': '$contentType'")
+      None
+    }
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/package.scala
@@ -59,11 +59,11 @@ package object mapping extends DebugEnhancedLogging {
 
   implicit class OptionExtensions[T](val t: Option[T]) extends AnyVal {
 
-    def doIfNone[A](log: () => Unit): Option[T] = {
+    def doIfNone[A](sideEffect: () => Unit): Option[T] = {
       t match {
         case Some(value) => Some(value)
         case None =>
-          log()
+          sideEffect()
           None
       }
     }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/package.scala
@@ -16,11 +16,12 @@
 package nl.knaw.dans.easy.dd2d
 
 import nl.knaw.dans.lib.dataverse.model.dataset.{ CompoundField, ControlledSingleValueField, MetadataField, PrimitiveSingleValueField }
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
 import scala.collection.mutable
 import scala.xml.Node
 
-package object mapping {
+package object mapping extends DebugEnhancedLogging {
   val XML_SCHEMA_INSTANCE_URI = "http://www.w3.org/2001/XMLSchema-instance"
 
   type JsonObject = Map[String, MetadataField]
@@ -55,4 +56,17 @@ package object mapping {
 
     def toJsonObject: JsonObject = fields.toMap
   }
+
+  implicit class OptionExtensions[T](val t: Option[T]) extends AnyVal {
+
+    def doIfNone[A](log: () => Unit): Option[T] = {
+      t match {
+        case Some(value) => Some(value)
+        case None =>
+          log()
+          None
+      }
+    }
+  }
 }
+


### PR DESCRIPTION
Fixes DD-280

# Description of changes
See: https://drivenbydata.atlassian.net/browse/DD-280

# How to test
1. Check out pr
2. Run `mvn clean install`
3. Deploy in dd-dtap: `./deploy-module.sh dd-dans-deposit-to-dataverse ` 
4. Add `    
 <dcterms:format>application/pdf</dcterms:format>
    <dcterms:type>Dataset</dcterms:type>
    <dc:format>text/html</dc:format>
    <dc:language xsi:type='dcterms:ISO639-2'>fre</dc:language>
    <dcterms:temporal xsi:type="abr:ABRperiode">PALEOLA</dcterms:temporal>`
to a test bags `dataset.xml`.
5. Disable bag validator in dtap (the xml won't validate but this is for testing only): `systemctl stop easy-validate-dans-bag`
6. Run: `vagrant ssh`
7. Copy test bag to inbox: `sudo cp -r /vagrant/{testbagdir} /var/opt/dans.knaw.nl/tmp/deposits-inbox/`
8. Run: `dd-dans-deposit-to-dataverse import /var/opt/dans.knaw.nl/tmp/deposits-inbox/`
9. Change CV values in xml and do step 7 and 8 aganin to see the error logging.
 

# Related PRs 
(Add links)
* 

# Notify
@DANS-KNAW/dataversedans
