### PR TITLE
DD-283: fix "No first version was found for dataset"

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositSorter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositSorter.scala
@@ -86,7 +86,7 @@ class DepositSorter extends TaskSorter[Deposit] with DebugEnhancedLogging {
   }
 
   private def removeDatasetsWithoutFirstVersion(firstVersions: baseIdToAllVersions, laterVersions: baseIdToAllVersions): baseIdToAllVersions = {
-    val datasetsWithoutFirstVersions = laterVersions.filter(k => firstVersions.contains(k._1))
+    val datasetsWithoutFirstVersions = laterVersions.filter(k => !firstVersions.contains(k._1))
     datasetsWithoutFirstVersions.foreach(v => logger.error(s"No first version was found for dataset ${ v._1 }. The dataset was not imported into Dataverse"))
     val correctVersions = for (k <- laterVersions if firstVersions.keySet.contains(k._1)) yield k
     correctVersions

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositSorter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositSorter.scala
@@ -86,7 +86,7 @@ class DepositSorter extends TaskSorter[Deposit] with DebugEnhancedLogging {
   }
 
   private def removeDatasetsWithoutFirstVersion(firstVersions: baseIdToAllVersions, laterVersions: baseIdToAllVersions): baseIdToAllVersions = {
-    val datasetsWithoutFirstVersions = laterVersions.filter(k => !firstVersions.contains(k._1))
+    val datasetsWithoutFirstVersions = laterVersions.filterNot(k => firstVersions.contains(k._1))
     datasetsWithoutFirstVersions.foreach(v => logger.error(s"No first version was found for dataset ${ v._1 }. The dataset was not imported into Dataverse"))
     val correctVersions = for (k <- laterVersions if firstVersions.keySet.contains(k._1)) yield k
     correctVersions


### PR DESCRIPTION
Fixes DD-283

# Description of changes
* add missing `!` to fix the filter for `datasetsWithoutFirstVersions`.

# How to test
* Follow steps in the issue on Jira

# Related PRs 
(Add links)
* 

# Notify
@DANS-KNAW/dataversedans
