### PR TITLE
DD-323: fix NARCIS to Dataverse subject mapping and restrict audience term to english

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Audience.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Audience.scala
@@ -89,7 +89,7 @@ object Audience extends BlockBasicInformation with DebugEnhancedLogging {
 
     Option(narcisToSubject
       .find { case (k, _) => node.text.startsWith(k) }
-      .getOrElse(("", "Other"))
-      ._2)
+      .map(_._2)
+      .getOrElse("Other"))
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Audience.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Audience.scala
@@ -84,6 +84,13 @@ object Audience extends BlockBasicInformation with DebugEnhancedLogging {
    * @return the Dataverse subject term
    */
   def toCitationBlockSubject(node: Node): Option[String] = {
-    Option(narcisToSubject.getOrElse(node.text, "Other"))
+    if (!node.text.matches("""^[D|E]\d{5}$""")) {
+      throw new RuntimeException("NARCIS classification code format incorrect")
+    }
+
+    Option(narcisToSubject
+      .find { case (k, _) => node.text.startsWith(k) }
+      .getOrElse(("", "Other"))
+      ._2)
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Audience.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Audience.scala
@@ -66,12 +66,11 @@ object Audience extends BlockBasicInformation with DebugEnhancedLogging {
    * @return the Dataverse subject term and url or None
    */
   private def getTermAndUrl(node: Node, narcisClassification: Elem): Option[TermAndUrl] = {
-    narcisClassification
-      .child
+    (narcisClassification \ "Description")
       .find(_.attributes.exists(_.value.text contains node.text))
       .map(description => {
-        val term = description.headOption.flatMap(_.child.find(_.label == "prefLabel")).map(_.text).getOrElse("")
-        val url = description.headOption.flatMap(_.attributes.value.headOption).getOrElse(SUBJECT_NARCIS_CLASSIFICATION_URL).toString
+        val term = (description \ "prefLabel").find(_.attributes.exists(_.value.text == "en")).map(_.text).getOrElse("")
+        val url = description.attributes.value.headOption.getOrElse(SUBJECT_NARCIS_CLASSIFICATION_URL).toString
         TermAndUrl(term, url)
       })
   }

--- a/src/test/scala/nl.knaw.dans.easy.dd2d/mapping/AudienceSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.dd2d/mapping/AudienceSpec.scala
@@ -53,7 +53,14 @@ class AudienceSpec extends TestSupportFixture with TableDrivenPropertyChecks {
     toCitationBlockSubject(audience) shouldBe Some("Other")
   }
 
-  "toBasicInformationBlockSubjectCv" should "return the correct Narcis classifications" in {
+  it should "throw a RuntimeException for an invalid NARCIS audience code" in {
+    val audience = <ddm:audience>INVALID</ddm:audience>
+    assertThrows[RuntimeException] {
+      toCitationBlockSubject(audience)
+    }
+  }
+
+  "toBasicInformationBlockSubjectCv" should "return the correct NARCIS classifications" in {
     val narcisAudiences = Table(
       ("audience", "term"),
       ("D11300", "Functions, differential equations"),


### PR DESCRIPTION
Fixes DD-323

# Description of changes
* Changed `toCitationBlockSubject` to throw a `RuntimeException` when an invalid NARCIS classification code is given.
* otherwise `toCitationBlockSubject` returns the correct Dataverse subject.
* Changed `getTermAndUrl` to only returns the English term.
* Changed `AudienceSpec` to test new behavior.

# How to test


# Related PRs 
(Add links)
* 

# Notify
@DANS-KNAW/dataversedans
