### PR TITLE
DD-357 - Separate folders for processed, failed and rejected deposits

### DIFF
--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -3,9 +3,7 @@
 #
 deposits.inbox=
 deposits.auto-publish=true
-deposits.processed=/var/opt/dans.knaw.nl/tmp/deposits-processed
-deposits.failed=/var/opt/dans.knaw.nl/tmp/deposits-failed
-deposits.rejected=/var/opt/dans.knaw.nl/tmp/deposits-rejected
+deposits.outbox=/var/opt/dans.knaw.nl/tmp/deposits-outbox
 
 #
 # Parameters related to communication with the Dataverse instance

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -3,6 +3,9 @@
 #
 deposits.inbox=
 deposits.auto-publish=true
+deposits.processed=/var/opt/dans.knaw.nl/tmp/deposits-processed
+deposits.failed=/var/opt/dans.knaw.nl/tmp/deposits-failed
+deposits.rejected=/var/opt/dans.knaw.nl/tmp/deposits-rejected
 
 #
 # Parameters related to communication with the Dataverse instance

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/Command.scala
@@ -36,8 +36,8 @@ object Command extends App with DebugEnhancedLogging {
     _ <- app.checkPreconditions()
     msg <- commandLine.subcommand match {
       case Some(cmd @ commandLine.importCommand) => {
-        if (cmd.singleDeposit()) app.importSingleDeposit(cmd.depositsInboxOrSingleDeposit(), !cmd.draft())
-        else app.importDeposits(cmd.depositsInboxOrSingleDeposit(), !cmd.draft())
+        if (cmd.singleDeposit()) app.importSingleDeposit(cmd.depositsInboxOrSingleDeposit(), !cmd.draft(), cmd.outdir())
+        else app.importDeposits(cmd.depositsInboxOrSingleDeposit(), !cmd.draft(), cmd.outdir())
       }.map(_ => "Done importing deposits")
       case Some(_ @ commandLine.runService) => runAsService()
       case _ => Try { s"Unknown command: ${ commandLine.subcommand }" }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/CommandLineOptions.scala
@@ -56,6 +56,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
     descr("Imports one ore more deposits. Does not monitor for new deposits to arrive, but instead terminates after importing the batch.")
     val singleDeposit: ScallopOption[Boolean] = opt(name = "single", descr = "Single deposit instead of a deposits inbox")
     val draft: ScallopOption[Boolean] = opt(name = "draft", descr = "Do not publish the resulting datasets, but keep them on DRAFT status")
+    val outdir: ScallopOption[Path] = opt(name = "outdir", descr = "Directory where deposits are moved to after import.", required = true)
     val depositsInboxOrSingleDeposit: ScallopOption[Path] = trailArg(name = "inbox-or-single-deposit",
       descr = "Directory containing as sub-directories the deposit dirs to be imported or a single deposit")
     validatePathExists(depositsInboxOrSingleDeposit)

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/Configuration.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/Configuration.scala
@@ -29,6 +29,9 @@ import scala.xml.{ Elem, XML }
 
 case class Configuration(version: String,
                          inboxDir: File,
+                         outboxDirRejected: File,
+                         outboxDirFailed: File,
+                         outboxDirProcessed: File,
                          validatorServiceUrl: URI,
                          validatorConnectionTimeoutMs: Int,
                          validatorReadTimeoutMs: Int,
@@ -68,6 +71,9 @@ object Configuration {
     new Configuration(
       version = (home / "bin" / "version").contentAsString.stripLineEnd,
       inboxDir = File(properties.getString("deposits.inbox")),
+      outboxDirRejected = File(properties.getString("deposits.rejected")),
+      outboxDirFailed = File(properties.getString("deposits.failed")),
+      outboxDirProcessed = File(properties.getString("deposits.processed")),
       validatorServiceUrl = new URI(properties.getString("validate-dans-bag.service-url")),
       validatorConnectionTimeoutMs = properties.getInt("validate-dans-bag.connection-timeout-ms"),
       validatorReadTimeoutMs = properties.getInt("validate-dans-bag.read-timeout-ms"),

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/Configuration.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/Configuration.scala
@@ -23,15 +23,14 @@ import org.apache.commons.csv.{ CSVFormat, CSVParser }
 
 import java.net.URI
 import java.nio.charset.StandardCharsets
+import java.nio.file.{ Path, Paths }
 import scala.collection.JavaConverters.asScalaIteratorConverter
 import scala.util.Try
 import scala.xml.{ Elem, XML }
 
 case class Configuration(version: String,
                          inboxDir: File,
-                         outboxDirRejected: File,
-                         outboxDirFailed: File,
-                         outboxDirProcessed: File,
+                         outboxDir: Path,
                          validatorServiceUrl: URI,
                          validatorConnectionTimeoutMs: Int,
                          validatorReadTimeoutMs: Int,
@@ -71,9 +70,7 @@ object Configuration {
     new Configuration(
       version = (home / "bin" / "version").contentAsString.stripLineEnd,
       inboxDir = File(properties.getString("deposits.inbox")),
-      outboxDirRejected = File(properties.getString("deposits.rejected")),
-      outboxDirFailed = File(properties.getString("deposits.failed")),
-      outboxDirProcessed = File(properties.getString("deposits.processed")),
+      outboxDir = Paths.get(properties.getString("deposits.outbox")),
       validatorServiceUrl = new URI(properties.getString("validate-dans-bag.service-url")),
       validatorConnectionTimeoutMs = properties.getInt("validate-dans-bag.connection-timeout-ms"),
       validatorReadTimeoutMs = properties.getInt("validate-dans-bag.read-timeout-ms"),

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DansDeposit2ToDataverseApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DansDeposit2ToDataverseApp.scala
@@ -86,9 +86,11 @@ class DansDeposit2ToDataverseApp(configuration: Configuration) extends DebugEnha
     inboxWatcher.stop()
   }
 
-  private def initOutboxDirs (outboxDir: Path): Unit = {
+  private def initOutboxDirs (outboxDir: Path): Try[Unit] = Try {
+    if (!File(outboxDir).isEmpty)
+      throw NonEmptyOutboxDirException(outboxDir.toString)
+
     File(outboxDir.toString.concat("/deposits-processed")).createDirectoryIfNotExists(true)
     File(outboxDir.toString.concat("/deposits-rejected")).createDirectoryIfNotExists(true)
-    File(outboxDir.toString.concat("/deposits-failed")).createDirectoryIfNotExists(true)
-  }
+    File(outboxDir.toString.concat("/deposits-failed")).createDirectoryIfNotExists(true)}
 }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DansDeposit2ToDataverseApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DansDeposit2ToDataverseApp.scala
@@ -39,7 +39,10 @@ class DansDeposit2ToDataverseApp(configuration: Configuration) extends DebugEnha
       configuration.publishAwaitUnlockMaxNumberOfRetries,
       configuration.publishAwaitUnlockMillisecondsBetweenRetries,
       configuration.narcisClassification,
-      configuration.isoToDataverseLanguage))
+      configuration.isoToDataverseLanguage,
+      configuration.outboxDirProcessed,
+      configuration.outboxDirRejected,
+      configuration.outboxDirFailed))
 
   def checkPreconditions(): Try[Unit] = {
     for {
@@ -56,7 +59,10 @@ class DansDeposit2ToDataverseApp(configuration: Configuration) extends DebugEnha
       configuration.publishAwaitUnlockMaxNumberOfRetries,
       configuration.publishAwaitUnlockMillisecondsBetweenRetries,
       configuration.narcisClassification,
-      configuration.isoToDataverseLanguage).process()
+      configuration.isoToDataverseLanguage,
+      configuration.outboxDirProcessed,
+      configuration.outboxDirRejected,
+      configuration.outboxDirFailed).process()
   }
 
   def importDeposits(inbox: File, autoPublish: Boolean): Try[Unit] = {
@@ -67,7 +73,10 @@ class DansDeposit2ToDataverseApp(configuration: Configuration) extends DebugEnha
       configuration.publishAwaitUnlockMaxNumberOfRetries,
       configuration.publishAwaitUnlockMillisecondsBetweenRetries,
       configuration.narcisClassification,
-      configuration.isoToDataverseLanguage)).process()
+      configuration.isoToDataverseLanguage,
+      configuration.outboxDirProcessed,
+      configuration.outboxDirRejected,
+      configuration.outboxDirFailed)).process()
   }
 
   def start(): Try[Unit] = {

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DansDeposit2ToDataverseApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DansDeposit2ToDataverseApp.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.easy.dd2d
 
 import better.files.File
+import nl.knaw.dans.easy.dd2d.OutboxSubdir.{ FAILED, PROCESSED, REJECTED }
 import nl.knaw.dans.easy.dd2d.dansbag.DansBagValidator
 import nl.knaw.dans.lib.dataverse.DataverseInstance
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
@@ -76,6 +77,7 @@ class DansDeposit2ToDataverseApp(configuration: Configuration) extends DebugEnha
       configuration.narcisClassification,
       configuration.isoToDataverseLanguage,
       outboxDir)).process()
+    deleteEmptyDepositsDir(inbox)
   }
 
   def start(): Try[Unit] = {
@@ -86,11 +88,16 @@ class DansDeposit2ToDataverseApp(configuration: Configuration) extends DebugEnha
     inboxWatcher.stop()
   }
 
-  private def initOutboxDirs (outboxDir: Path): Try[Unit] = Try {
+  private def initOutboxDirs(outboxDir: Path): Try[Unit] = Try {
     if (!File(outboxDir).isEmpty)
       throw NonEmptyOutboxDirException(outboxDir.toString)
 
-    File(outboxDir.toString.concat("/deposits-processed")).createDirectoryIfNotExists(true)
-    File(outboxDir.toString.concat("/deposits-rejected")).createDirectoryIfNotExists(true)
-    File(outboxDir.toString.concat("/deposits-failed")).createDirectoryIfNotExists(true)}
+    File(outboxDir.toString.concat(PROCESSED.toString)).createDirectoryIfNotExists(true)
+    File(outboxDir.toString.concat(REJECTED.toString)).createDirectoryIfNotExists(true)
+    File(outboxDir.toString.concat(FAILED.toString)).createDirectoryIfNotExists(true)
+  }
+
+  private def deleteEmptyDepositsDir(inbox: File): Try[Unit] = Try {
+    inbox.delete(true)
+  }
 }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTask.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTask.scala
@@ -84,7 +84,7 @@ case class DepositIngestTask(deposit: Deposit,
 
   def moveDepositToOutbox(subDir: OutboxSubdir): Unit = {
     try {
-      deposit.dir.copyToDirectory(File(outboxDir.toString.concat(subDir.toString)))
+      deposit.dir.copyToDirectory(File(outboxDir) / subDir.toString))
       deposit.dir.delete()
     } catch {
       case e: Exception => logger.info(s"Failed to move deposit: $deposit to the designated outbox : $e")

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/Inbox.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/Inbox.scala
@@ -21,6 +21,7 @@ import nl.knaw.dans.lib.dataverse.DataverseInstance
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import nl.knaw.dans.lib.taskqueue.AbstractInbox
 
+import java.nio.file.Path
 import scala.xml.Elem
 
 /**
@@ -37,9 +38,7 @@ class Inbox(dir: File,
             publishAwaitUnlockMillisecondsBetweenRetries: Int,
             narcisClassification: Elem,
             isoToDataverseLanage: Map[String, String],
-            outboxDirProcessed: File,
-            outboxRejected: File,
-            outboxFailed: File) extends AbstractInbox[Deposit](dir) with DebugEnhancedLogging {
+            outboxDir: Path) extends AbstractInbox[Deposit](dir) with DebugEnhancedLogging {
   override def createTask(f: File): Option[DepositIngestTask] = {
     try {
       Some(DepositIngestTask(
@@ -51,9 +50,7 @@ class Inbox(dir: File,
         publishAwaitUnlockMillisecondsBetweenRetries,
         narcisClassification,
         isoToDataverseLanage,
-        outboxDirProcessed,
-        outboxRejected,
-        outboxFailed))
+        outboxDir: Path))
     }
     catch {
       case e: InvalidDepositException =>

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/Inbox.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/Inbox.scala
@@ -36,7 +36,10 @@ class Inbox(dir: File,
             publishAwaitUnlockMaxNumberOfRetries: Int,
             publishAwaitUnlockMillisecondsBetweenRetries: Int,
             narcisClassification: Elem,
-            isoToDataverseLanage: Map[String, String]) extends AbstractInbox[Deposit](dir) with DebugEnhancedLogging {
+            isoToDataverseLanage: Map[String, String],
+            outboxDirProcessed: File,
+            outboxRejected: File,
+            outboxFailed: File) extends AbstractInbox[Deposit](dir) with DebugEnhancedLogging {
   override def createTask(f: File): Option[DepositIngestTask] = {
     try {
       Some(DepositIngestTask(
@@ -47,7 +50,10 @@ class Inbox(dir: File,
         publishAwaitUnlockMaxNumberOfRetries,
         publishAwaitUnlockMillisecondsBetweenRetries,
         narcisClassification,
-        isoToDataverseLanage))
+        isoToDataverseLanage,
+        outboxDirProcessed,
+        outboxRejected,
+        outboxFailed))
     }
     catch {
       case e: InvalidDepositException =>

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/SingleDepositProcessor.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/SingleDepositProcessor.scala
@@ -30,7 +30,10 @@ class SingleDepositProcessor(deposit: File,
                              publishAwaitUnlockMaxNumberOfRetries: Int,
                              publishAwaitUnlockMillisecondsBetweenRetries: Int,
                              narcisClassification: Elem,
-                             isoToDataverseLanage: Map[String, String]) {
+                             isoToDataverseLanage: Map[String, String],
+                             outboxDirProcessed: File,
+                             outboxDirRejected: File,
+                             outboxDirFailed: File) {
   def process(): Try[Unit] = Try {
     val ingestTasks = new PassiveTaskQueue[Deposit]()
     ingestTasks.add(
@@ -42,7 +45,10 @@ class SingleDepositProcessor(deposit: File,
         publishAwaitUnlockMaxNumberOfRetries,
         publishAwaitUnlockMillisecondsBetweenRetries,
         narcisClassification,
-        isoToDataverseLanage))
+        isoToDataverseLanage,
+        outboxDirProcessed,
+        outboxDirRejected,
+        outboxDirFailed))
     ingestTasks.process()
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/SingleDepositProcessor.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/SingleDepositProcessor.scala
@@ -20,6 +20,7 @@ import nl.knaw.dans.easy.dd2d.dansbag.DansBagValidator
 import nl.knaw.dans.lib.dataverse.DataverseInstance
 import nl.knaw.dans.lib.taskqueue.PassiveTaskQueue
 
+import java.nio.file.Path
 import scala.util.Try
 import scala.xml.Elem
 
@@ -31,9 +32,7 @@ class SingleDepositProcessor(deposit: File,
                              publishAwaitUnlockMillisecondsBetweenRetries: Int,
                              narcisClassification: Elem,
                              isoToDataverseLanage: Map[String, String],
-                             outboxDirProcessed: File,
-                             outboxDirRejected: File,
-                             outboxDirFailed: File) {
+                             outboxDir: Path) {
   def process(): Try[Unit] = Try {
     val ingestTasks = new PassiveTaskQueue[Deposit]()
     ingestTasks.add(
@@ -46,9 +45,7 @@ class SingleDepositProcessor(deposit: File,
         publishAwaitUnlockMillisecondsBetweenRetries,
         narcisClassification,
         isoToDataverseLanage,
-        outboxDirProcessed,
-        outboxDirRejected,
-        outboxDirFailed))
+        outboxDir))
     ingestTasks.process()
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/package.scala
@@ -58,4 +58,11 @@ package object dd2d {
 
   case class NonEmptyOutboxDirException(outboxDir: String)
     extends Exception(s"Output directory: $outboxDir already contains results")
+
+  object OutboxSubdir extends Enumeration {
+    type OutboxSubdir = Value
+    val PROCESSED = Value("/deposits-processed")
+    val REJECTED = Value("/deposits-rejected")
+    val FAILED = Value("/deposits-failed")
+  }
 }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/package.scala
@@ -16,7 +16,6 @@
 package nl.knaw.dans.easy
 
 import better.files.File
-import nl.knaw.dans.easy.dd2d.mapping.JsonObject
 import nl.knaw.dans.lib.dataverse.model.file.FileMeta
 import org.apache.commons.lang.StringUtils
 
@@ -56,4 +55,7 @@ package object dd2d {
 
   case class MissingRequiredFieldException(fieldName: String)
     extends Exception(s"No value found for required field: $fieldName")
+
+  case class NonEmptyOutboxDirException(outboxDir: String)
+    extends Exception(s"Output directory: $outboxDir already contains results")
 }

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -3,6 +3,9 @@
 #
 deposits.inbox=data/inbox/
 deposits.auto-publish=true
+deposits.processed=/var/opt/dans.knaw.nl/tmp/processed/
+deposits.failed=/var/opt/dans.knaw.nl/tmp/failed/
+deposits.rejected=/var/opt/dans.knaw.nl/tmp/rejected/
 
 #
 # Parameters related to communication with the Dataverse instance

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -3,9 +3,7 @@
 #
 deposits.inbox=data/inbox/
 deposits.auto-publish=true
-deposits.processed=/var/opt/dans.knaw.nl/tmp/processed/
-deposits.failed=/var/opt/dans.knaw.nl/tmp/failed/
-deposits.rejected=/var/opt/dans.knaw.nl/tmp/rejected/
+deposits.outbox=/var/opt/dans.knaw.nl/tmp/outbox
 
 #
 # Parameters related to communication with the Dataverse instance

--- a/src/test/scala/nl.knaw.dans.easy.dd2d/DepositIngestTaskSortSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.dd2d/DepositIngestTaskSortSpec.scala
@@ -52,6 +52,6 @@ class DepositIngestTaskSortSpec extends TestSupportFixture with MockFactory {
   //  }
 
   private def createDepositIngestTask(directory: File): DepositIngestTask = {
-    DepositIngestTask(Deposit(directory), dansBagValidator, dataverseInstance, publish = false, 3, 500, null, null)
+    DepositIngestTask(Deposit(directory), dansBagValidator, dataverseInstance, publish = false, 3, 500, null, null, null, null, null)
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.dd2d/DepositIngestTaskSortSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.dd2d/DepositIngestTaskSortSpec.scala
@@ -52,6 +52,6 @@ class DepositIngestTaskSortSpec extends TestSupportFixture with MockFactory {
   //  }
 
   private def createDepositIngestTask(directory: File): DepositIngestTask = {
-    DepositIngestTask(Deposit(directory), dansBagValidator, dataverseInstance, publish = false, 3, 500, null, null, null, null, null)
+    DepositIngestTask(Deposit(directory), dansBagValidator, dataverseInstance, publish = false, 3, 500, null, null, null)
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.dd2d/IndexSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.dd2d/IndexSpec.scala
@@ -25,6 +25,9 @@ class IndexSpec extends TestSupportFixture {
   private val configuration = Configuration(
     version = "my-version",
     inboxDir = null,
+    outboxDirRejected = null,
+    outboxDirFailed = null,
+    outboxDirProcessed = null,
     validatorServiceUrl = null,
     validatorConnectionTimeoutMs = 1000,
     validatorReadTimeoutMs= 1000,

--- a/src/test/scala/nl.knaw.dans.easy.dd2d/IndexSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.dd2d/IndexSpec.scala
@@ -25,9 +25,7 @@ class IndexSpec extends TestSupportFixture {
   private val configuration = Configuration(
     version = "my-version",
     inboxDir = null,
-    outboxDirRejected = null,
-    outboxDirFailed = null,
-    outboxDirProcessed = null,
+    outboxDir = null,
     validatorServiceUrl = null,
     validatorConnectionTimeoutMs = 1000,
     validatorReadTimeoutMs= 1000,


### PR DESCRIPTION
Fixes [DD-357](https://drivenbydata.atlassian.net/browse/DD-357)

# Description of changes
Deposits are moved to designated outdir after import.

# How to test
**Using default outdir**
vagrant ssh
`cp -r <depositdir> /var/opt/dans.knaw.nl/tmp/deposits-inbox`
`dd-dans-deposit-to-dataverse run-service`
Check if dirs are created in `/var/opt/dans.knaw.nl/tmp/deposits-outbox` and the `deposits-processed` subdirectory contains the deposit.

**Using --outdir command line option**
vagrant ssh
`dd-dans-deposit-to-dataverse import --<outdir> -s <depositdir>`
Check if dirs are created in specified outdir and the `deposits-processed` subdirectory contains the imported deposit.

Do the same with an invalid and a failed deposit to see that they are placed in respectively the `deposits-rejected` and `deposits-failed` directories.
# Related PRs 
(Add links)
* 

# Notify
@DANS-KNAW/dataversedans
