### PR TITLE
DD-357. Some improvements

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/CommandLineOptions.scala
@@ -56,9 +56,9 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
     descr("Imports one ore more deposits. Does not monitor for new deposits to arrive, but instead terminates after importing the batch.")
     val singleDeposit: ScallopOption[Boolean] = opt(name = "single", descr = "Single deposit instead of a deposits inbox")
     val draft: ScallopOption[Boolean] = opt(name = "draft", descr = "Do not publish the resulting datasets, but keep them on DRAFT status")
-    val outdir: ScallopOption[Path] = opt(name = "outdir", descr = "Directory where deposits are moved to after import.", required = true)
     val depositsInboxOrSingleDeposit: ScallopOption[Path] = trailArg(name = "inbox-or-single-deposit",
       descr = "Directory containing as sub-directories the deposit dirs to be imported or a single deposit")
+    val outdir: ScallopOption[Path] = trailArg(name = "outdir", descr = "Directory where deposits are moved to after import.", required = true)
     validatePathExists(depositsInboxOrSingleDeposit)
     footer(SUBCOMMAND_SEPARATOR)
   }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTask.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTask.scala
@@ -44,7 +44,7 @@ case class DepositIngestTask(deposit: Deposit,
                              publishAwaitUnlockMillisecondsBetweenRetries: Int,
                              narcisClassification: Elem,
                              isoToDataverseLanguage: Map[String, String],
-                             outboxDir: Path) extends Task[Deposit] with DebugEnhancedLogging {
+                             outboxDir: File) extends Task[Deposit] with DebugEnhancedLogging {
   trace(deposit, instance)
 
   private val mapper = new DepositToDataverseMapper(narcisClassification, isoToDataverseLanguage)
@@ -84,10 +84,9 @@ case class DepositIngestTask(deposit: Deposit,
 
   def moveDepositToOutbox(subDir: OutboxSubdir): Unit = {
     try {
-      deposit.dir.copyToDirectory(File(outboxDir) / subDir.toString)
-      deposit.dir.delete()
+      deposit.dir.moveToDirectory(outboxDir / subDir.toString)
     } catch {
-      case e: Exception => logger.info(s"Failed to move deposit: $deposit to the designated outbox : $e")
+      case e: Exception => logger.info(s"Failed to move deposit: $deposit to ${outboxDir / subDir.toString}", e)
     }
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/Inbox.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/Inbox.scala
@@ -38,7 +38,7 @@ class Inbox(dir: File,
             publishAwaitUnlockMillisecondsBetweenRetries: Int,
             narcisClassification: Elem,
             isoToDataverseLanage: Map[String, String],
-            outboxDir: Path) extends AbstractInbox[Deposit](dir) with DebugEnhancedLogging {
+            outboxDir: File) extends AbstractInbox[Deposit](dir) with DebugEnhancedLogging {
   override def createTask(f: File): Option[DepositIngestTask] = {
     try {
       Some(DepositIngestTask(
@@ -50,7 +50,7 @@ class Inbox(dir: File,
         publishAwaitUnlockMillisecondsBetweenRetries,
         narcisClassification,
         isoToDataverseLanage,
-        outboxDir: Path))
+        outboxDir: File))
     }
     catch {
       case e: InvalidDepositException =>

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/SingleDepositProcessor.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/SingleDepositProcessor.scala
@@ -32,7 +32,7 @@ class SingleDepositProcessor(deposit: File,
                              publishAwaitUnlockMillisecondsBetweenRetries: Int,
                              narcisClassification: Elem,
                              isoToDataverseLanage: Map[String, String],
-                             outboxDir: Path) {
+                             outboxDir: File) {
   def process(): Try[Unit] = Try {
     val ingestTasks = new PassiveTaskQueue[Deposit]()
     ingestTasks.add(

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/package.scala
@@ -56,13 +56,16 @@ package object dd2d {
   case class MissingRequiredFieldException(fieldName: String)
     extends Exception(s"No value found for required field: $fieldName")
 
-  case class NonEmptyOutboxDirException(outboxDir: String)
+  case class ExistingResultsInOutboxException(outboxDir: File)
     extends Exception(s"Output directory: $outboxDir already contains results")
+
+  case class OutboxDirIsRegularFileException(outboxDir: File)
+    extends Exception(s"Output directory: $outboxDir is a regular file.")
 
   object OutboxSubdir extends Enumeration {
     type OutboxSubdir = Value
-    val PROCESSED = Value("/deposits-processed")
-    val REJECTED = Value("/deposits-rejected")
-    val FAILED = Value("/deposits-failed")
+    val PROCESSED = Value("processed")
+    val REJECTED = Value("rejected")
+    val FAILED = Value("failed")
   }
 }


### PR DESCRIPTION
Fixes DD-357

# Description of changes
* Changed the `--outdir` option to a second trailing argument, as that was more intuitive when using the command line.
* Removed `initOutboxDirs` from the service start-up, as the outdir may be non-empty when the service restarts, and that is not a problem.
* Made sure the resulting Try of `initOutboxDirs` is used.
* Changed `java.nio.Path` to `better.files.File` in a couple of places.
* Fixed a problem with the subdirectory names, which were interpreted as absolute paths.

# How to test


# Related PRs 
(Add links)
* 

# Notify
@DANS-KNAW/dataversedans
