### PR TITLE
DD-369 Let dd-dans-deposit-to-dataverse only try to fill in active metadata blocks + more md mappings

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DansDeposit2ToDataverseApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DansDeposit2ToDataverseApp.scala
@@ -52,7 +52,8 @@ class DansDeposit2ToDataverseApp(configuration: Configuration) extends DebugEnha
 
   def importSingleDeposit(deposit: File, autoPublish: Boolean, outboxDir: File): Try[Unit] = {
     for {
-      _ <- initOutboxDirs(outboxDir)
+      _ <- initOutboxDirs(outboxDir, requireAbsenceOfResults = false)
+      - <- mustNotExist(OutboxSubdir.values.map(_.toString).map(subdir => outboxDir / subdir / deposit.name).toList)
       _ <- new SingleDepositProcessor(deposit,
         dansBagValidator,
         dataverse,
@@ -88,18 +89,27 @@ class DansDeposit2ToDataverseApp(configuration: Configuration) extends DebugEnha
     inboxWatcher.stop()
   }
 
-  private def initOutboxDirs(outboxDir: File): Try[Unit] = Try {
+  private def initOutboxDirs(outboxDir: File, requireAbsenceOfResults: Boolean = true): Try[Unit] = Try {
     trace(outboxDir)
     val subDirs = List(outboxDir / OutboxSubdir.PROCESSED.toString,
       outboxDir / OutboxSubdir.FAILED.toString,
       outboxDir / OutboxSubdir.REJECTED.toString)
 
-    if (outboxDir.isRegularFile)
-      throw OutboxDirIsRegularFileException(outboxDir)
-    if (subDirs.exists(d => d.isDirectory && d.nonEmpty))
-      throw ExistingResultsInOutboxException(outboxDir)
-
+    mustBeDirectory(outboxDir)
+    if (requireAbsenceOfResults) mustBeEmptyDirectories(subDirs)
     outboxDir.createDirectoryIfNotExists(createParents = true)
     subDirs.foreach(_.createDirectories())
+  }
+
+  private def mustBeEmptyDirectories(dirs: List[File]): Try[Unit] = Try {
+    dirs.find(d => d.isDirectory && d.nonEmpty).map(d => throw ExistingResultsInOutboxException(d))
+  }
+
+  private def mustBeDirectory(d: File): Try[Unit] = Try {
+    if (d.isRegularFile) throw OutboxDirIsRegularFileException(d)
+  }
+
+  private def mustNotExist(fs: List[File]): Try[Unit] = Try {
+    fs.find(_.exists).map(d => throw ExistingResultsInOutboxException(d))
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTask.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTask.scala
@@ -70,7 +70,8 @@ case class DepositIngestTask(deposit: Deposit,
       user <- response.data
       datasetContacts <- createDatasetContacts(user.displayName, user.email)
       ddm <- deposit.tryDdm
-      dataverseDataset <- mapper.toDataverseDataset(ddm, datasetContacts, deposit.vaultMetadata)
+      optAgreements <- deposit.tryOptAgreementsXml
+      dataverseDataset <- mapper.toDataverseDataset(ddm, optAgreements, datasetContacts, deposit.vaultMetadata)
       isUpdate <- deposit.isUpdate
       _ = debug(s"isUpdate? = $isUpdate")
       editor = if (isUpdate) new DatasetUpdater(deposit, dataverseDataset.datasetVersion.metadataBlocks, instance)

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTask.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTask.scala
@@ -37,6 +37,7 @@ import scala.xml.Elem
  * @param instance the Dataverse instance to ingest in
  */
 case class DepositIngestTask(deposit: Deposit,
+                             activeMetadataBlocks: List[String],
                              dansBagValidator: DansBagValidator,
                              instance: DataverseInstance,
                              publish: Boolean = true,
@@ -47,7 +48,7 @@ case class DepositIngestTask(deposit: Deposit,
                              outboxDir: File) extends Task[Deposit] with DebugEnhancedLogging {
   trace(deposit, instance)
 
-  private val mapper = new DepositToDataverseMapper(narcisClassification, isoToDataverseLanguage)
+  private val mapper = new DepositToDataverseMapper(activeMetadataBlocks, narcisClassification, isoToDataverseLanguage)
   private val bagDirPath = File(deposit.bagDir.path)
 
   override def run(): Try[Unit] = doRun()

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositToDataverseMapper.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositToDataverseMapper.scala
@@ -33,11 +33,13 @@ class DepositToDataverseMapper(narcisClassification: Elem, isoToDataverseLanguag
   with BlockArchaeologySpecific
   with BlockTemporalAndSpatial
   with BlockRights
+  with BlockCollection
   with BlockDataVaultMetadata {
   lazy val citationFields = new mutable.HashMap[String, AbstractFieldBuilder]()
+  lazy val rightsFields = new mutable.HashMap[String, AbstractFieldBuilder]()
+  lazy val collectionFields = new mutable.HashMap[String, AbstractFieldBuilder]()
   lazy val archaeologySpecificFields = new mutable.HashMap[String, AbstractFieldBuilder]()
   lazy val temporalSpatialFields = new mutable.HashMap[String, AbstractFieldBuilder]()
-  lazy val rightsFields = new mutable.HashMap[String, AbstractFieldBuilder]()
   lazy val dataVaultFields = new mutable.HashMap[String, AbstractFieldBuilder]()
 
   def toDataverseDataset(ddm: Node, optAgreements: Option[Node], contactData: List[JsonObject], vaultMetadata: VaultMetadata): Try[Dataset] = Try {
@@ -101,7 +103,7 @@ class DepositToDataverseMapper(narcisClassification: Elem, isoToDataverseLanguag
     }
 
     // Collection
-    // TODO: add collection block
+    addCompoundFieldMultipleValues(collectionFields, COLLECTION, ddm \ "dcmiMetadata" \ "inCollection", Collection toCollection)
 
     // Data vault
     addPrimitiveFieldSingleValue(dataVaultFields, BAG_ID, Option(vaultMetadata.dataverseBagId))
@@ -120,9 +122,10 @@ class DepositToDataverseMapper(narcisClassification: Elem, isoToDataverseLanguag
   private def assembleDataverseDataset(): Dataset = {
     val versionMap = mutable.Map[String, MetadataBlock]()
     addMetadataBlock(versionMap, "citation", "Citation Metadata", citationFields)
+    addMetadataBlock(versionMap, "dansRights", "Rights Metadata", rightsFields)
+    addMetadataBlock(versionMap, "dansCollection", "Collection Metadata", collectionFields)
     addMetadataBlock(versionMap, "dansArchaeologyMetadata", "Archaeology-Specific Metadata", archaeologySpecificFields)
     addMetadataBlock(versionMap, "dansTemporalSpatial", "Temporal and Spatial Coverage", temporalSpatialFields)
-    addMetadataBlock(versionMap, "dansRights", "Rights Metadata", rightsFields)
     addMetadataBlock(versionMap, "dansDataVaultMetadata", "Data Vault Metadata", dataVaultFields)
     val datasetVersion = DatasetVersion(metadataBlocks = versionMap.toMap)
     Dataset(datasetVersion)

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositToDataverseMapper.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositToDataverseMapper.scala
@@ -29,7 +29,7 @@ import scala.xml.{ Elem, Node, NodeSeq }
  * Maps DANS Dataset Metadata to Dataverse JSON.
  */
 // TODO: Rename if we also need to take elements from EMD
-class DepositToDataverseMapper(narcisClassification: Elem, isoToDataverseLanguage: Map[String, String]) extends BlockCitation
+class DepositToDataverseMapper(activeMetadataBlocks: List[String], narcisClassification: Elem, isoToDataverseLanguage: Map[String, String]) extends BlockCitation
   with BlockArchaeologySpecific
   with BlockTemporalAndSpatial
   with BlockRights
@@ -45,72 +45,84 @@ class DepositToDataverseMapper(narcisClassification: Elem, isoToDataverseLanguag
   def toDataverseDataset(ddm: Node, optAgreements: Option[Node], contactData: List[JsonObject], vaultMetadata: VaultMetadata): Try[Dataset] = Try {
     // Please, keep ordered by order in Dataverse UI as much as possible (note, if display-on-create is not set for all fields, some may be hidden initally)
 
-    val titles = ddm \ "profile" \ "title"
-    if (titles.isEmpty) throw MissingRequiredFieldException("title")
+    if (activeMetadataBlocks.contains("citation")) {
+      val titles = ddm \ "profile" \ "title"
+      if (titles.isEmpty) throw MissingRequiredFieldException("title")
 
-    val alternativeTitles = (ddm \ "dcmiMetadata" \ "title") ++ (ddm \ "dcmiMetadata" \ "alternative")
+      val alternativeTitles = (ddm \ "dcmiMetadata" \ "title") ++ (ddm \ "dcmiMetadata" \ "alternative")
 
-    // Citation
-    addPrimitiveFieldSingleValue(citationFields, TITLE, titles.head)
-    addPrimitiveFieldSingleValue(citationFields, ALTERNATIVE_TITLE, alternativeTitles)
-    addCompoundFieldMultipleValues(citationFields, OTHER_ID, ddm \ "dcmiMetadata" \ "isFormatOf", IsFormatOf toOtherIdValueObject)
-    addCompoundFieldMultipleValues(citationFields, AUTHOR, ddm \ "profile" \ "creatorDetails" \ "author", DcxDaiAuthor toAuthorValueObject)
-    addCompoundFieldMultipleValues(citationFields, AUTHOR, ddm \ "profile" \ "creatorDetails" \ "organization", DcxDaiOrganization toAuthorValueObject)
-    addCompoundFieldMultipleValues(citationFields, AUTHOR, ddm \ "profile" \ "creator", Creator toAuthorValueObject)
-    addCompoundFieldMultipleValues(citationFields, DATASET_CONTACT, contactData)
-    addCompoundFieldMultipleValues(citationFields, DESCRIPTION, ddm \ "profile" \ "description", Description toDescriptionValueObject)
-    addCompoundFieldMultipleValues(citationFields, DESCRIPTION, if (alternativeTitles.isEmpty) NodeSeq.Empty
-                                                                else alternativeTitles.tail, Description toDescriptionValueObject)
-    val otherDescriptions = (ddm \ "dcmiMetadata" \ "date") ++
-      (ddm \ "dcmiMetadata" \ "dateAccepted") ++
-      (ddm \ "dcmiMetadata" \ "dateCopyrighted ") ++
-      (ddm \ "dcmiMetadata" \ "dateSubmitted") ++
-      (ddm \ "dcmiMetadata" \ "modified") ++
-      (ddm \ "dcmiMetadata" \ "issued") ++
-      (ddm \ "dcmiMetadata" \ "valid") ++
-      (ddm \ "dcmiMetadata" \ "coverage")
-    addCompoundFieldMultipleValues(citationFields, DESCRIPTION, otherDescriptions, Description toPrefixedDescription)
+      addPrimitiveFieldSingleValue(citationFields, TITLE, titles.head)
+      addPrimitiveFieldSingleValue(citationFields, ALTERNATIVE_TITLE, alternativeTitles)
+      addCompoundFieldMultipleValues(citationFields, OTHER_ID, ddm \ "dcmiMetadata" \ "isFormatOf", IsFormatOf toOtherIdValueObject)
+      addCompoundFieldMultipleValues(citationFields, AUTHOR, ddm \ "profile" \ "creatorDetails" \ "author", DcxDaiAuthor toAuthorValueObject)
+      addCompoundFieldMultipleValues(citationFields, AUTHOR, ddm \ "profile" \ "creatorDetails" \ "organization", DcxDaiOrganization toAuthorValueObject)
+      addCompoundFieldMultipleValues(citationFields, AUTHOR, ddm \ "profile" \ "creator", Creator toAuthorValueObject)
+      addCompoundFieldMultipleValues(citationFields, DATASET_CONTACT, contactData)
+      addCompoundFieldMultipleValues(citationFields, DESCRIPTION, ddm \ "profile" \ "description", Description toDescriptionValueObject)
+      addCompoundFieldMultipleValues(citationFields, DESCRIPTION, if (alternativeTitles.isEmpty) NodeSeq.Empty
+                                                                  else alternativeTitles.tail, Description toDescriptionValueObject)
+      val otherDescriptions = (ddm \ "dcmiMetadata" \ "date") ++
+        (ddm \ "dcmiMetadata" \ "dateAccepted") ++
+        (ddm \ "dcmiMetadata" \ "dateCopyrighted ") ++
+        (ddm \ "dcmiMetadata" \ "dateSubmitted") ++
+        (ddm \ "dcmiMetadata" \ "modified") ++
+        (ddm \ "dcmiMetadata" \ "issued") ++
+        (ddm \ "dcmiMetadata" \ "valid") ++
+        (ddm \ "dcmiMetadata" \ "coverage")
+      addCompoundFieldMultipleValues(citationFields, DESCRIPTION, otherDescriptions, Description toPrefixedDescription)
 
-    checkRequiredField(SUBJECT, ddm \ "profile" \ "audience")
-    addCvFieldMultipleValues(citationFields, SUBJECT, ddm \ "profile" \ "audience", Audience toCitationBlockSubject)
-    addCvFieldMultipleValues(citationFields, LANGUAGE, ddm \ "dcmiMetadata" \ "language", Language.toCitationBlockLanguage(isoToDataverseLanguage))
-    addPrimitiveFieldSingleValue(citationFields, PRODUCTION_DATE, ddm \ "profile" \ "created", DateTypeElement toYearMonthDayFormat)
-    addCompoundFieldMultipleValues(citationFields, CONTRIBUTOR, ddm \ "dcmiMetadata" \ "contributorDetails" \ "author", DcxDaiAuthor toContributorValueObject)
-    addCompoundFieldMultipleValues(citationFields, CONTRIBUTOR, ddm \ "dcmiMetadata" \ "contributorDetails" \ "organization", DcxDaiOrganization toContributorValueObject)
-    addPrimitiveFieldSingleValue(citationFields, DISTRIBUTION_DATE, ddm \ "profile" \ "available", DateTypeElement toYearMonthDayFormat)
-    addPrimitiveFieldMultipleValues(citationFields, DATA_SOURCES, ddm \ "dcmiMetadata" \ "source")
-
-    // Archaeology specific
-    addPrimitiveFieldMultipleValues(archaeologySpecificFields, ARCHIS_ZAAK_ID, ddm \ "dcmiMetadata" \ "identifier", IsFormatOf toArchisZaakId)
-    addCompoundFieldMultipleValues(archaeologySpecificFields, ABR_RAPPORT_TYPE, (ddm \ "dcmiMetadata" \ "reportNumber").filter(AbrReportType isAbrReportType), AbrReportType toAbrRapportType)
-    addPrimitiveFieldMultipleValues(archaeologySpecificFields, ABR_RAPPORT_NUMMER, ddm \ "dcmiMetadata" \ "reportNumber")
-    addCompoundFieldMultipleValues(archaeologySpecificFields, ABR_VERWERVINGSWIJZE, (ddm \ "dcmiMetadata" \ "acquisitionMethod").filter(AbrAcquisitionMethod isAbrVerwervingswijze), AbrAcquisitionMethod toVerwervingswijze)
-    addCompoundFieldMultipleValues(archaeologySpecificFields, ABR_COMPLEX, (ddm \ "dcmiMetadata" \ "subject").filter(SubjectAbr isAbrComplex), SubjectAbr toAbrComplex)
-    addCompoundFieldMultipleValues(archaeologySpecificFields, ABR_PERIOD, (ddm \ "dcmiMetadata" \ "temporal").filter(TemporalAbr isAbrPeriod), TemporalAbr toAbrPeriod)
-
-    // Temporal and spatial coverage
-    addPrimitiveFieldMultipleValues(temporalSpatialFields, TEMPORAL_COVERAGE, ddm \ "dcmiMetadata" \ "temporal")
-    addCompoundFieldMultipleValues(temporalSpatialFields, SPATIAL_POINT, (ddm \ "dcmiMetadata" \ "spatial").filter(_.child.exists(_.label == "Point")), SpatialPoint toEasyTsmSpatialPointValueObject)
-    addCompoundFieldMultipleValues(temporalSpatialFields, SPATIAL_BOX, ddm \ "dcmiMetadata" \ "spatial" \ "boundedBy", SpatialBox toEasyTsmSpatialBoxValueObject)
-    addCvFieldMultipleValues(temporalSpatialFields, SPATIAL_COVERAGE_CONTROLLED, (ddm \ "dcmiMetadata" \ "spatial").filterNot(_.child.exists(_.isInstanceOf[Elem])), SpatialCoverage toControlledSpatialValue)
-    addPrimitiveFieldMultipleValues(temporalSpatialFields, SPATIAL_COVERAGE_UNCONTROLLED, (ddm \ "dcmiMetadata" \ "spatial").filterNot(_.child.exists(_.isInstanceOf[Elem])), SpatialCoverage toUncontrolledSpatialValue)
-
-    // Rights
-    checkRequiredField(RIGHTS_HOLDER, ddm \ "dcmiMetadata" \ "rightsHolder")
-    addPrimitiveFieldMultipleValues(rightsFields, RIGHTS_HOLDER, ddm \ "dcmiMetadata" \ "rightsHolder", AnyElement toText)
-    optAgreements.foreach { agreements =>
-      addCvFieldSingleValue(rightsFields, PERSONAL_DATA_PRESENT, agreements \ "personalDataStatement", PersonalStatement toHasPersonalDataValue)
+      checkRequiredField(SUBJECT, ddm \ "profile" \ "audience")
+      addCvFieldMultipleValues(citationFields, SUBJECT, ddm \ "profile" \ "audience", Audience toCitationBlockSubject)
+      addCvFieldMultipleValues(citationFields, LANGUAGE, ddm \ "dcmiMetadata" \ "language", Language.toCitationBlockLanguage(isoToDataverseLanguage))
+      addPrimitiveFieldSingleValue(citationFields, PRODUCTION_DATE, ddm \ "profile" \ "created", DateTypeElement toYearMonthDayFormat)
+      addCompoundFieldMultipleValues(citationFields, CONTRIBUTOR, ddm \ "dcmiMetadata" \ "contributorDetails" \ "author", DcxDaiAuthor toContributorValueObject)
+      addCompoundFieldMultipleValues(citationFields, CONTRIBUTOR, ddm \ "dcmiMetadata" \ "contributorDetails" \ "organization", DcxDaiOrganization toContributorValueObject)
+      addPrimitiveFieldSingleValue(citationFields, DISTRIBUTION_DATE, ddm \ "profile" \ "available", DateTypeElement toYearMonthDayFormat)
+      addPrimitiveFieldMultipleValues(citationFields, DATA_SOURCES, ddm \ "dcmiMetadata" \ "source")
+    }
+    else {
+      throw new IllegalStateException("Metadatablock citation should always be active")
     }
 
-    // Collection
-    addCompoundFieldMultipleValues(collectionFields, COLLECTION, ddm \ "dcmiMetadata" \ "inCollection", Collection toCollection)
+    if (activeMetadataBlocks.contains("dansRights")) {
+      checkRequiredField(RIGHTS_HOLDER, ddm \ "dcmiMetadata" \ "rightsHolder")
+      addPrimitiveFieldMultipleValues(rightsFields, RIGHTS_HOLDER, ddm \ "dcmiMetadata" \ "rightsHolder", AnyElement toText)
+      optAgreements.foreach { agreements =>
+        addCvFieldSingleValue(rightsFields, PERSONAL_DATA_PRESENT, agreements \ "personalDataStatement", PersonalStatement toHasPersonalDataValue)
+      }
+    }
 
-    // Data vault
-    addPrimitiveFieldSingleValue(dataVaultFields, BAG_ID, Option(vaultMetadata.dataverseBagId))
-    addPrimitiveFieldSingleValue(dataVaultFields, NBN, Option(vaultMetadata.dataverseNbn))
-    addPrimitiveFieldSingleValue(dataVaultFields, DANS_OTHER_ID, Option(vaultMetadata.dataverseOtherId))
-    addPrimitiveFieldSingleValue(dataVaultFields, DANS_OTHER_ID_VERSION, Option(vaultMetadata.dataverseOtherIdVersion))
-    addPrimitiveFieldSingleValue(dataVaultFields, SWORD_TOKEN, Option(vaultMetadata.dataverseSwordToken))
+    if (activeMetadataBlocks.contains("dansCollectionMetadata")) {
+      addCompoundFieldMultipleValues(collectionFields, COLLECTION, ddm \ "dcmiMetadata" \ "inCollection", Collection toCollection)
+    }
+
+    if (activeMetadataBlocks.contains("dansArchaeologyMetadata")) {
+      addPrimitiveFieldMultipleValues(archaeologySpecificFields, ARCHIS_ZAAK_ID, ddm \ "dcmiMetadata" \ "identifier", IsFormatOf toArchisZaakId)
+      addCompoundFieldMultipleValues(archaeologySpecificFields, ABR_RAPPORT_TYPE, (ddm \ "dcmiMetadata" \ "reportNumber").filter(AbrReportType isAbrReportType), AbrReportType toAbrRapportType)
+      addPrimitiveFieldMultipleValues(archaeologySpecificFields, ABR_RAPPORT_NUMMER, ddm \ "dcmiMetadata" \ "reportNumber")
+      addCompoundFieldMultipleValues(archaeologySpecificFields, ABR_VERWERVINGSWIJZE, (ddm \ "dcmiMetadata" \ "acquisitionMethod").filter(AbrAcquisitionMethod isAbrVerwervingswijze), AbrAcquisitionMethod toVerwervingswijze)
+      addCompoundFieldMultipleValues(archaeologySpecificFields, ABR_COMPLEX, (ddm \ "dcmiMetadata" \ "subject").filter(SubjectAbr isAbrComplex), SubjectAbr toAbrComplex)
+      addCompoundFieldMultipleValues(archaeologySpecificFields, ABR_PERIOD, (ddm \ "dcmiMetadata" \ "temporal").filter(TemporalAbr isAbrPeriod), TemporalAbr toAbrPeriod)
+    }
+
+    if (activeMetadataBlocks.contains("dansTemporalSpatial")) {
+      addPrimitiveFieldMultipleValues(temporalSpatialFields, TEMPORAL_COVERAGE, ddm \ "dcmiMetadata" \ "temporal")
+      addCompoundFieldMultipleValues(temporalSpatialFields, SPATIAL_POINT, (ddm \ "dcmiMetadata" \ "spatial").filter(_.child.exists(_.label == "Point")), SpatialPoint toEasyTsmSpatialPointValueObject)
+      addCompoundFieldMultipleValues(temporalSpatialFields, SPATIAL_BOX, ddm \ "dcmiMetadata" \ "spatial" \ "boundedBy", SpatialBox toEasyTsmSpatialBoxValueObject)
+      addCvFieldMultipleValues(temporalSpatialFields, SPATIAL_COVERAGE_CONTROLLED, (ddm \ "dcmiMetadata" \ "spatial").filterNot(_.child.exists(_.isInstanceOf[Elem])), SpatialCoverage toControlledSpatialValue)
+      addPrimitiveFieldMultipleValues(temporalSpatialFields, SPATIAL_COVERAGE_UNCONTROLLED, (ddm \ "dcmiMetadata" \ "spatial").filterNot(_.child.exists(_.isInstanceOf[Elem])), SpatialCoverage toUncontrolledSpatialValue)
+    }
+
+    if (activeMetadataBlocks.contains("dansDataVaultMetadata")) {
+      addPrimitiveFieldSingleValue(dataVaultFields, BAG_ID, Option(vaultMetadata.dataverseBagId))
+      addPrimitiveFieldSingleValue(dataVaultFields, NBN, Option(vaultMetadata.dataverseNbn))
+      addPrimitiveFieldSingleValue(dataVaultFields, DANS_OTHER_ID, Option(vaultMetadata.dataverseOtherId))
+      addPrimitiveFieldSingleValue(dataVaultFields, DANS_OTHER_ID_VERSION, Option(vaultMetadata.dataverseOtherIdVersion))
+      addPrimitiveFieldSingleValue(dataVaultFields, SWORD_TOKEN, Option(vaultMetadata.dataverseSwordToken))
+    }
+    else {
+      throw new IllegalStateException("Metadatablock dansDataVaultMetadata should always be active")
+    }
 
     assembleDataverseDataset()
   }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/Inbox.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/Inbox.scala
@@ -32,6 +32,7 @@ import scala.xml.Elem
  * @param dataverse the DataverseInstance to use for the DepositIngestTasks
  */
 class Inbox(dir: File,
+            activeMetadataBlocks: List[String],
             dansBagValidator: DansBagValidator,
             dataverse: DataverseInstance, autoPublish: Boolean = true,
             publishAwaitUnlockMaxNumberOfRetries: Int,
@@ -43,6 +44,7 @@ class Inbox(dir: File,
     try {
       Some(DepositIngestTask(
         Deposit(f),
+        activeMetadataBlocks,
         dansBagValidator,
         dataverse,
         autoPublish,

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/SingleDepositProcessor.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/SingleDepositProcessor.scala
@@ -25,6 +25,7 @@ import scala.util.Try
 import scala.xml.Elem
 
 class SingleDepositProcessor(deposit: File,
+                             activeMetadataBlocks: List[String],
                              dansBagValidator: DansBagValidator,
                              dataverse: DataverseInstance,
                              autoPublish: Boolean = true,
@@ -38,6 +39,7 @@ class SingleDepositProcessor(deposit: File,
     ingestTasks.add(
       DepositIngestTask(
         Deposit(deposit),
+        activeMetadataBlocks,
         dansBagValidator,
         dataverse,
         publish = autoPublish,

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/BlockCollection.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/BlockCollection.scala
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2020 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.dd2d.mapping
+
+trait BlockCollection {
+  val COLLECTION = "dansCollection"
+  val COLLECTION_VOCABULARY = "dansCollectionVocabulary"
+  val COLLECTION_VOCABULARY_URI = "dansCollectionVocabularyURI"
+  val COLLECTION_TERM = "dansCollectionTerm"
+  val COLLECTION_TERM_URI = "dansCollectionTermURI"
+}

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/BlockRights.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/BlockRights.scala
@@ -17,4 +17,5 @@ package nl.knaw.dans.easy.dd2d.mapping
 
 trait BlockRights {
   val RIGHTS_HOLDER = "dansRightsHolder"
+  val PERSONAL_DATA_PRESENT = "dansPersonalDataPresent"
 }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Collection.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Collection.scala
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2020 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.dd2d.mapping
+
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+
+import scala.xml.Node
+
+object Collection extends BlockCollection with DebugEnhancedLogging {
+  def toCollection(node: Node): JsonObject = {
+    // TODO: also take attribute namespace into account (should be ddm)
+    val optSubjectScheme = node.attribute("subjectScheme").flatMap(_.headOption).map(_.text).doIfNone(() => logger.error("Missing subjectScheme attribute on ddm:inCollection node"))
+    val optSchemeUri = node.attribute("schemeURI").flatMap(_.headOption).map(_.text).doIfNone(() => logger.error("Missing schemeURI attribute on ddm:inCollection node"))
+    val optValueUri = node.attribute("valueURI").flatMap(_.headOption).map(_.text).doIfNone(() => logger.error("Missing valueURI attribute on ddm:inCollectionr node"))
+    val term = node.text
+
+    val m = FieldMap()
+    m.addPrimitiveField(COLLECTION_VOCABULARY, optSubjectScheme.get)
+    m.addPrimitiveField(COLLECTION_VOCABULARY_URI, optSchemeUri.get)
+    m.addPrimitiveField(COLLECTION_TERM, term)
+    m.addPrimitiveField(COLLECTION_TERM_URI, optValueUri.get)
+    m.toJsonObject
+  }
+}

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/DateTypeElement.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/DateTypeElement.scala
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.easy.dd2d.mapping
 
+import nl.knaw.dans.easy.dd2d.mapping.Description.DESCRIPTION_VALUE
 import org.joda.time.DateTime
 import org.joda.time.format.{ DateTimeFormat, DateTimeFormatter }
 

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Description.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Description.scala
@@ -15,9 +15,22 @@
  */
 package nl.knaw.dans.easy.dd2d.mapping
 
+import nl.knaw.dans.easy.dd2d.mapping.DateTypeElement.labelToDateType
+
 import scala.xml.Node
 
 object Description extends BlockCitation {
+  private val labelToPrefix = Map(
+    "date" -> "Date",
+    "valid" -> "Valid",
+    "issued" -> "Issued",
+    "modified" -> "Modified",
+    "dateAccepted" -> "Date Accepted",
+    "dateCopyrighted" -> "Date Copyrighted",
+    "coverage" -> "Coverage"
+  )
+
+
 
   def toDescriptionValueObject(node: Node): JsonObject = {
     val m = FieldMap()
@@ -25,4 +38,12 @@ object Description extends BlockCitation {
     // TODO: add date subfield?
     m.toJsonObject
   }
+
+  def toPrefixedDescription(node: Node): JsonObject = {
+    val prefix = labelToPrefix.getOrElse(node.label, node.label)
+    val m = FieldMap()
+    m.addPrimitiveField(DESCRIPTION_VALUE, s"$prefix: ${node.text}")
+    m.toJsonObject
+  }
+
 }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/PersonalStatement.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/PersonalStatement.scala
@@ -17,18 +17,13 @@ package nl.knaw.dans.easy.dd2d.mapping
 
 import scala.xml.Node
 
-object SpatialPoint extends Spatial with BlockTemporalAndSpatial {
-  def toEasyTsmSpatialPointValueObject(spatial: Node): JsonObject = {
-    val isRD = isRd(spatial) // TODO: improve error handling
-    // TODO: Only one Point expected here, but should be more robust
-    val pointElem = (spatial \ "Point").head
-    val p = getPoint(pointElem)
-    val m = FieldMap()
+object PersonalStatement {
 
-    m.addCvField(SPATIAL_POINT_SCHEME, if (isRD) RD_SCHEME
-                                       else LATLON_SCHEME)
-    m.addPrimitiveField(SPATIAL_POINT_X, p.x)
-    m.addPrimitiveField(SPATIAL_POINT_Y, p.y)
-    m.toJsonObject
+  def toHasPersonalDataValue(personalStatement: Node): Option[String] = {
+    if ((personalStatement \ "notAvailable").nonEmpty) Option("Unknown")
+    else (personalStatement \ "containsPrivacySensitiveData")
+      .map(_.text.toBoolean)
+      .map(yes => if (yes) "Yes"
+                  else "No").headOption
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/SpatialCoverage.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/SpatialCoverage.scala
@@ -15,18 +15,23 @@
  */
 package nl.knaw.dans.easy.dd2d.mapping
 
-trait BlockTemporalAndSpatial {
-  val TEMPORAL_COVERAGE = "dansTemporalCoverage"
-  val SPATIAL_POINT = "dansSpatialPoint"
-  val SPATIAL_POINT_SCHEME = "dansSpatialPointScheme"
-  val SPATIAL_POINT_X = "dansSpatialPointX"
-  val SPATIAL_POINT_Y = "dansSpatialPointY"
-  val SPATIAL_BOX = "dansSpatialBox"
-  val SPATIAL_BOX_SCHEME = "dansSpatialBoxScheme"
-  val SPATIAL_BOX_NORTH = "dansSpatialBoxNorth"
-  val SPATIAL_BOX_EAST = "dansSpatialBoxEast"
-  val SPATIAL_BOX_SOUTH = "dansSpatialBoxSouth"
-  val SPATIAL_BOX_WEST = "dansSpatialBoxWest"
-  val SPATIAL_COVERAGE_CONTROLLED = "dansSpatialCoverageControlled"
-  val SPATIAL_COVERAGE_UNCONTROLLED = "dansSpatialCoverageText"
+import scala.xml.Node
+
+object SpatialCoverage extends Spatial with BlockTemporalAndSpatial {
+  private val controlledValues = List(
+    "Netherlands",
+    "United Kingdom",
+    "Belgium",
+    "Germany"
+  )
+
+  def toControlledSpatialValue(node: Node): Option[String] = {
+    if (controlledValues.contains(node.text)) Some(node.text)
+    else Option.empty
+  }
+
+  def toUncontrolledSpatialValue(node: Node): Option[String] = {
+    if (controlledValues.contains(node.text)) Option.empty
+    else Some(node.text)
+  }
 }

--- a/src/test/resources/examples/valid-easy-submitted/example-bag-medium/metadata/depositor-info/agreements.xml
+++ b/src/test/resources/examples/valid-easy-submitted/example-bag-medium/metadata/depositor-info/agreements.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2019 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<agreements xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/bag/metadata/agreements/ https://easy.dans.knaw.nl/schemas/bag/metadata/agreements/agreements.xsd"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:dcterms="http://purl.org/dc/terms/"
+            xmlns="http://easy.dans.knaw.nl/schemas/bag/metadata/agreements/"
+>
+    <depositAgreement>
+        <signerId easy-account="user001" email="info@dans.knaw.nl">MisterX</signerId>
+        <dcterms:dateAccepted>2018-03-22T21:43:01.000+01:00</dcterms:dateAccepted>
+        <depositAgreementAccepted>true</depositAgreementAccepted>
+    </depositAgreement>
+    <personalDataStatement>
+        <signerId easy-account="user001" email="info@dans.knaw.nl">MisterX</signerId>
+        <dateSigned>2018-03-22T21:43:01.000+01:00</dateSigned>
+        <containsPrivacySensitiveData>false</containsPrivacySensitiveData>
+    </personalDataStatement>
+</agreements>

--- a/src/test/resources/examples/valid-easy-submitted/example-bag-medium/tagmanifest-sha1.txt
+++ b/src/test/resources/examples/valid-easy-submitted/example-bag-medium/tagmanifest-sha1.txt
@@ -1,5 +1,6 @@
 7d2525837cde8f99a4a05f910c7373d81b62104b  bag-info.txt
-a86facd12b34ef15e1e38efc332f8d7de36fdc94  metadata/dataset.xml
+55fb72e63018156e2d5460e2d7e7a3df3f75dff9  metadata/dataset.xml
 e2924b081506bac23f5fffe650ad1848a1c8ac1d  bagit.txt
 5b063a488773654a7829d3b63bdfc7cc31fb6f0f  manifest-sha1.txt
-f476f2e61e7906ca9377ce6a02a6c10bc05f74d5  metadata/files.xml
+ea8f9087263a30db0a22c2cfe9324d882c20d471  metadata/files.xml
+3d2b8d876064f716c28474de33e7a975b3dae9b3  metadata/depositor-info/agreements.xml

--- a/src/test/scala/nl.knaw.dans.easy.dd2d/DepositIngestTaskSortSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.dd2d/DepositIngestTaskSortSpec.scala
@@ -52,6 +52,6 @@ class DepositIngestTaskSortSpec extends TestSupportFixture with MockFactory {
   //  }
 
   private def createDepositIngestTask(directory: File): DepositIngestTask = {
-    DepositIngestTask(Deposit(directory), dansBagValidator, dataverseInstance, publish = false, 3, 500, null, null, null)
+    DepositIngestTask(Deposit(directory), null, dansBagValidator, dataverseInstance, publish = false, 3, 500, null, null, null)
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.dd2d/DepositToDataverseMapperSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.dd2d/DepositToDataverseMapperSpec.scala
@@ -23,7 +23,7 @@ import scala.util.Success
 class DepositToDataverseMapperSpec extends TestSupportFixture {
 
   implicit val format: DefaultFormats.type = DefaultFormats
-  private val mapper = new DepositToDataverseMapper(null, null)
+  private val mapper = new DepositToDataverseMapper(List("citation", "dansDataVaultMetadata"),null, null)
   private val vaultMetadata = Deposit(testDirValid / "valid-easy-submitted").vaultMetadata
   private val optAgreements = Deposit(testDirValid / "valid-easy-submitted").tryOptAgreementsXml.get
   private val contactData = List(toFieldMap(

--- a/src/test/scala/nl.knaw.dans.easy.dd2d/DepositToDataverseMapperSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.dd2d/DepositToDataverseMapperSpec.scala
@@ -25,6 +25,7 @@ class DepositToDataverseMapperSpec extends TestSupportFixture {
   implicit val format: DefaultFormats.type = DefaultFormats
   private val mapper = new DepositToDataverseMapper(null, null)
   private val vaultMetadata = Deposit(testDirValid / "valid-easy-submitted").vaultMetadata
+  private val optAgreements = Deposit(testDirValid / "valid-easy-submitted").tryOptAgreementsXml.get
   private val contactData = List(toFieldMap(
     PrimitiveSingleValueField("datasetContactName", "Contact Name"),
     PrimitiveSingleValueField("datasetContactEmail", "contact@example.org")
@@ -42,7 +43,7 @@ class DepositToDataverseMapperSpec extends TestSupportFixture {
         </ddm:dcmiMetadata>
       </ddm:DDM>
 
-    val result = mapper.toDataverseDataset(ddm, contactData, vaultMetadata)
+    val result = mapper.toDataverseDataset(ddm, optAgreements, contactData, vaultMetadata)
     result shouldBe a[Success[_]]
     inside(result) {
       case Success(Dataset(dsv)) =>
@@ -66,7 +67,7 @@ class DepositToDataverseMapperSpec extends TestSupportFixture {
         </ddm:dcmiMetadata>
       </ddm:DDM>
 
-    val result = mapper.toDataverseDataset(ddm, contactData, vaultMetadata)
+    val result = mapper.toDataverseDataset(ddm, optAgreements, contactData, vaultMetadata)
     result shouldBe a[Success[_]]
     inside(result) {
       case Success(Dataset(dsv)) =>
@@ -113,7 +114,7 @@ class DepositToDataverseMapperSpec extends TestSupportFixture {
           </ddm:dcmiMetadata>
       </ddm:DDM>
 
-    val result = mapper.toDataverseDataset(ddm, contactData, vaultMetadata)
+    val result = mapper.toDataverseDataset(ddm, optAgreements, contactData, vaultMetadata)
     result shouldBe a[Success[_]]
     inside(result) {
       case Success(Dataset(dsv)) =>

--- a/src/test/scala/nl.knaw.dans.easy.dd2d/mapping/PersonalStatementSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.dd2d/mapping/PersonalStatementSpec.scala
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2020 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.dd2d.mapping
+
+import nl.knaw.dans.easy.dd2d.TestSupportFixture
+
+class PersonalStatementSpec extends TestSupportFixture {
+
+  "toHasPersonalData" should "return No if <containsPrivacySensitiveData> contains false" in {
+    val statement = <personalDataStatement>
+        <signerId easy-account="user001" email="info@dans.knaw.nl">MisterX</signerId>
+        <dateSigned>2018-03-22T21:43:01.000+01:00</dateSigned>
+        <containsPrivacySensitiveData>false</containsPrivacySensitiveData>
+    </personalDataStatement>
+
+    PersonalStatement.toHasPersonalDataValue(statement) shouldBe Some("No")
+  }
+
+  it should "return Yes if <containsPrivacySensitiveData> contains true" in {
+    val statement = <personalDataStatement>
+        <signerId easy-account="user001" email="info@dans.knaw.nl">MisterX</signerId>
+        <dateSigned>2018-03-22T21:43:01.000+01:00</dateSigned>
+        <containsPrivacySensitiveData>true</containsPrivacySensitiveData>
+    </personalDataStatement>
+
+    PersonalStatement.toHasPersonalDataValue(statement) shouldBe Some("Yes")
+  }
+
+  it should "return Unknown if statement contains <notAvailable/>" in {
+    val statement = <personalDataStatement><notAvailable/></personalDataStatement>
+
+    PersonalStatement.toHasPersonalDataValue(statement) shouldBe Some("Unknown")
+  }
+
+  it should "return None if statement contains no specifying element" in {
+    val statement = <personalDataStatement><blah/></personalDataStatement>
+
+    PersonalStatement.toHasPersonalDataValue(statement) shouldBe None
+  }
+
+
+
+}

--- a/src/test/scala/nl.knaw.dans.easy.dd2d/mapping/SpatialPointSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.dd2d/mapping/SpatialPointSpec.scala
@@ -22,10 +22,13 @@ import org.json4s.{ DefaultFormats, Formats }
 import scala.util.{ Failure, Try }
 
 class SpatialPointSpec extends TestSupportFixture with BlockTemporalAndSpatial {
-  private implicit val jsonFormats: Formats = new DefaultFormats {}
+  private implicit val jsonFormats: Formats = DefaultFormats
 
   "toEasyTsmSpatialPointValueObject" should "create correct spatial point details in Json object" in {
-    val spatialPoint = <gml:pos>52.08113 4.34510</gml:pos>
+    val spatialPoint =
+      <spatial>
+        <Point>52.08113 4.34510</Point>
+      </spatial>
     val result = Serialization.writePretty(SpatialPoint.toEasyTsmSpatialPointValueObject(spatialPoint))
     findString(result, s"$SPATIAL_POINT_SCHEME.value") shouldBe "latitude/longitude (m)"
     findString(result, s"$SPATIAL_POINT_X.value") shouldBe "52.08113"
@@ -33,7 +36,10 @@ class SpatialPointSpec extends TestSupportFixture with BlockTemporalAndSpatial {
   }
 
   it should "give 'RD(in m.)' as spatial point scheme and coordinates as integers" in {
-    val spatialPoint = <gml:pos srsName="http://www.opengis.net/def/crs/EPSG/0/28992">469470 209942</gml:pos>
+    val spatialPoint =
+      <spatial srsName="http://www.opengis.net/def/crs/EPSG/0/28992">
+        <Point>469470 209942</Point>
+      </spatial>
     val result = Serialization.writePretty(SpatialPoint.toEasyTsmSpatialPointValueObject(spatialPoint))
     findString(result, s"$SPATIAL_POINT_SCHEME.value") shouldBe "RD(in m.)"
     findString(result, s"$SPATIAL_POINT_X.value") shouldBe "469470"
@@ -41,7 +47,10 @@ class SpatialPointSpec extends TestSupportFixture with BlockTemporalAndSpatial {
   }
 
   it should "throw exception when spatial point coordinates are given incorrectly" in {
-    val spatialPoint = <gml:pos>52.08113, 4.34510</gml:pos>
+    val spatialPoint =
+      <spatial srsName="http://www.opengis.net/def/crs/EPSG/0/28992">
+        <Point>52.08113, 4.34510</Point>
+      </spatial>
     inside(Try(SpatialPoint.toEasyTsmSpatialPointValueObject(spatialPoint))) {
       case Failure(e: NumberFormatException) => e.getMessage should include("52.08113,")
     }


### PR DESCRIPTION
Fixes DD-369

# Description of changes
* Blocks are now only filled in if they are present and active in the target dataverse
* Implemented more mappings: dansCollection, dansPersonalDataPresent
* Improved checks on existing output for `import` command: when doing a single deposit, outdir does not need to be empty, but the same deposit must not be there.
* Fixed location scheme bug on Points.

# How to test


# Related PRs 
(Add links)
* 

# Notify
@DANS-KNAW/dataversedans
