### PR TITLE
DD-449 - Use "release migrated" function from dans-deposit-to-dataverse

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetCreator.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetCreator.scala
@@ -15,12 +15,10 @@
  */
 package nl.knaw.dans.easy.dd2d
 
-import nl.knaw.dans.lib.dataverse.model.RoleAssignment
 import nl.knaw.dans.lib.dataverse.model.dataset.{ Dataset, DatasetCreationResult }
 import nl.knaw.dans.lib.dataverse.{ DataverseInstance, DataverseResponse }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
-import javax.management.relation.Role
 import scala.util.Try
 
 class DatasetCreator(deposit: Deposit, dataverseDataset: Dataset, instance: DataverseInstance) extends DatasetEditor(instance) with DebugEnhancedLogging {

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetEditor.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetEditor.scala
@@ -27,13 +27,14 @@ import scala.util.Try
  */
 abstract class DatasetEditor(instance: DataverseInstance) extends DebugEnhancedLogging {
   type PersistendId = String
+  type DatasetId = Int
 
   /**
    * Performs the task.
    *
    * @return the persistentId of the dataset created or modified
    */
-  def performEdit(): Try[PersistendId]
+  def performEdit(): Try[DatasetIdentifiers]
 
   protected def addFiles(persistentId: String, files: List[FileInfo]): Try[Map[Int, FileInfo]] = {
     trace(persistentId, files)

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Amd.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Amd.scala
@@ -26,7 +26,7 @@ object Amd {
       }
   }
 
-  private def getFirstChangeToState(amd: Node, state: String): Option[String] = {
+  def getFirstChangeToState(amd: Node, state: String): Option[String] = {
     (amd \ "stateChangeDates" \ "stateChangeDate")
       .filter(sc => (sc \ "toState").text == state)
       .toList

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/package.scala
@@ -44,6 +44,8 @@ package object dd2d {
 
   case class FileInfo(file: File, checksum: String, metadata: FileMeta)
 
+  case class DatasetIdentifiers(datasetId: Int, persistentId: String)
+
   case class RejectedDepositException(deposit: Deposit, msg: String, cause: Throwable = null)
     extends Exception(s"Rejected ${ deposit.dir }: $msg", cause)
 


### PR DESCRIPTION
Fixes DD-449

# Description of changes
added support for import of publication date

# How to test
1. Use latest archaeology base box
2. check out https://github.com/DANS-KNAW/dans-dataverse-scala-lib/pull/10 and run mvn clean install
3. check out this pr and run mvn clean install (this should add dans-dataverse-scala-lib to the dependencies)
4. check out  https://github.com/IQSS/dataverse/pull/7504 and run mvn clean install
5. redeploy .war file in dd-dtap
6. deploy module dd-dans-deposit-to-dataverse in dd-dtap
7. import a dataset with an amd file
8. Check the publication date

# Related PRs 
(Add links)
* https://github.com/DANS-KNAW/dans-dataverse-scala-lib/pull/10

# Notify
@DANS-KNAW/dataversedans
