### PR TITLE
DD-453 Added required field check in mapper for dansRightsHolder

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositToDvDatasetMetadataMapper.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositToDvDatasetMetadataMapper.scala
@@ -102,6 +102,7 @@ class DepositToDvDatasetMetadataMapper(activeMetadataBlocks: List[String],
     }
 
     if (activeMetadataBlocks.contains("dansRights")) {
+      checkRequiredField(RIGHTS_HOLDER, ddm \ "dcmiMetadata" \ "rightsHolder")
       addPrimitiveFieldMultipleValues(rightsFields, RIGHTS_HOLDER, ddm \ "dcmiMetadata" \ "rightsHolder", AnyElement toText)
       optAgreements.foreach { agreements =>
         addCvFieldSingleValue(rightsFields, PERSONAL_DATA_PRESENT, agreements \ "personalDataStatement", PersonalStatement toHasPersonalDataValue)


### PR DESCRIPTION
Fixes DD-453

# Description of changes
Added a check that `dansRightsHolder` is filled in the mapper (as is done for all required fields). This is a double-check in most cases because the DDM schema already requires the field to be filled.

# How to test
To test this you would need to disable the DDM schema validation and input a deposit without a rights holder.

# Related PRs 
(Add links)
* 

# Notify
@DANS-KNAW/dataversedans
