### PR TITLE
Built in an option to skip validation during import

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,8 @@ SYNOPSIS
 --------
 
     dd-dans-deposit-to-dataverse run-service
-    dd-dans-deposit-to-dataverse import [-d,--draft] [-c,--continue] <inbox> <outbox>
-    dd-dans-deposit-to-dataverse import [-d,--draft] -s <single-deposit> <outbox>
+    dd-dans-deposit-to-dataverse import [-c,--continue] [--skip-validation] <inbox> <outbox>
+    dd-dans-deposit-to-dataverse import -s [--skip-validation] <single-deposit> <outbox>
 
 DESCRIPTION
 -----------
@@ -42,39 +42,26 @@ The processing of a deposit consists of the following steps:
 3. Map the dataset level metadata to the metadata fields expected in the target Dataverse.
 4. If:
     * deposit represents first version of a dataset: create a new dataset draft.
-    * deposit represents an update to an existing dataset: [draft a new version](#update-deposit)  
-5. Publish the new dataset-version if auto-publish is on.
-
-!!! note "Contact info"
-
-    In the current version of the tool the contact information is always that of the dataverseAdmin account.
-    This is a temporary solution and will change once the relevant requirements have been analysed.
+    * deposit represents an update to an existing dataset: [draft a new version](#update-deposit)
+5. Publish the new dataset-version.
 
 #### Update deposit
-When receiving a deposit that specifies a new version for an exsiting dataset (an update-deposit) the assumption
+When receiving a deposit that specifies a new version for an existing dataset (an update-deposit) the assumption
 is that the bag contains the metadata and file data that must be in the new version. This means:
 
-* The metadata specified completely overwrites the metadata in the latest version. So, if the client needs to
+* The metadata specified completely overwrites the metadata in the latest version. So, even if the client needs to
   change only one word, it must send all the existing metadata with only that particular word changed. Any 
   metadata left out will be deleted.
 * The files will replace the files in the latest version. So the files that are in the deposit are the ones
   that will be in the new version. If a file is to be deleted from the new version, it should simply be left
-  out in the deposit.
+  out in the deposit. If a file is to remain unchanged in the new version, an exact copy of the current file must be sent.
   
-  More exactly. Let:
-  
-  * R<sub>old</sub> = checksums of files to be replaced
-  * R<sub>new</sub> = checksums of replacements for R<sub>old</sub>
-  * D = checksums of files to be deleted
-  * A = checksums of files to be added
-  * L = checksums of files in latest version
-  * I = checksums of files in deposit
-    
-  Then:
+!!! note "File path is key"
 
-  * R = the files with the same (directoryLabel, label) in deposit and latest version but different checksums
-  * D = (L - R<sub>old</sub>) - I 
-  * A = (I - R<sub>new</sub>) - L 
+    The local file path (that is, directoryLabel + name) is used as the key to determine what file in the
+    latest published version, if any, is targetting. For example, to replace a published file, the path
+    of the replacement must match the path of the published file. (The path in the deposit is the path
+    relative to the bag's `data/` folder.)
     
 ### Mapping to Dataverse dataset
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,8 @@ SYNOPSIS
 --------
 
     dd-dans-deposit-to-dataverse run-service
-    dd-dans-deposit-to-dataverse import [-c,--continue] [--skip-validation] <inbox> <outbox>
-    dd-dans-deposit-to-dataverse import -s [--skip-validation] <single-deposit> <outbox>
+    dd-dans-deposit-to-dataverse import [--skip-validation] [-c,--continue] <inbox> <outbox>
+    dd-dans-deposit-to-dataverse import [--skip-validation] -s <single-deposit> <outbox>
 
 DESCRIPTION
 -----------

--- a/src/main/assembly/dist/cfg/logback-service.xml
+++ b/src/main/assembly/dist/cfg/logback-service.xml
@@ -20,5 +20,5 @@
         <appender-ref ref="FILE"/>
         <appender-ref ref="JOURNAL" />
     </root>
-    <logger name="nl.knaw.dans.easy" level="info"/>
+    <logger name="nl.knaw.dans" level="info"/>
 </configuration>

--- a/src/main/assembly/dist/cfg/logback.xml
+++ b/src/main/assembly/dist/cfg/logback.xml
@@ -19,5 +19,5 @@
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>
-    <logger name="nl.knaw.dans.easy" level="info"/>
+    <logger name="nl.knaw.dans" level="info"/>
 </configuration>

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/Command.scala
@@ -32,9 +32,8 @@ object Command extends App with DebugEnhancedLogging {
   }
 
   val app = new DansDeposit2ToDataverseApp(configuration)
-  val result = for {
-    _ <- app.checkPreconditions()
-    msg <- commandLine.subcommand match {
+  val result =
+    commandLine.subcommand match {
       case Some(cmd @ commandLine.importCommand) => {
         if (cmd.singleDeposit()) app.importSingleDeposit(cmd.depositsInboxOrSingleDeposit(), cmd.outdir(), cmd.skipValidation())
         else app.importDeposits(cmd.depositsInboxOrSingleDeposit(), cmd.outdir(), !cmd.continue(), cmd.skipValidation())
@@ -42,8 +41,6 @@ object Command extends App with DebugEnhancedLogging {
       case Some(_ @ commandLine.runService) => runAsService()
       case _ => Try { s"Unknown command: ${ commandLine.subcommand }" }
     }
-  } yield msg
-
   result.doIfSuccess(msg => Console.err.println(s"OK: $msg"))
     .doIfFailure { case e => logger.error(e.getMessage, e) }
     .doIfFailure { case NonFatal(e) => Console.err.println(s"FAILED: ${ e.getMessage }") }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/Command.scala
@@ -36,8 +36,8 @@ object Command extends App with DebugEnhancedLogging {
     _ <- app.checkPreconditions()
     msg <- commandLine.subcommand match {
       case Some(cmd @ commandLine.importCommand) => {
-        if (cmd.singleDeposit()) app.importSingleDeposit(cmd.depositsInboxOrSingleDeposit(), cmd.outdir())
-        else app.importDeposits(cmd.depositsInboxOrSingleDeposit(), cmd.outdir(), !cmd.draft(), !cmd.continue())
+        if (cmd.singleDeposit()) app.importSingleDeposit(cmd.depositsInboxOrSingleDeposit(), cmd.outdir(), cmd.skipValidation())
+        else app.importDeposits(cmd.depositsInboxOrSingleDeposit(), cmd.outdir(), !cmd.continue(), cmd.skipValidation())
       }.map(_ => "Done importing deposits")
       case Some(_ @ commandLine.runService) => runAsService()
       case _ => Try { s"Unknown command: ${ commandLine.subcommand }" }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/CommandLineOptions.scala
@@ -29,8 +29,8 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   val synopsis: String =
     s"""
        |  $printedName run-service
-       |  $printedName import [-c,--continue] [--skip-validation] <inbox> <outbox>
-       |  $printedName import -s [--skip-validation] <single-deposit> <outbox>
+       |  $printedName import [--skip-validation] [-c,--continue] <inbox> <outbox>
+       |  $printedName import [--skip-validation] -s <single-deposit> <outbox>
        |  """.stripMargin
 
   version(s"$printedName v${ configuration.version }")

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/CommandLineOptions.scala
@@ -29,8 +29,8 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   val synopsis: String =
     s"""
        |  $printedName run-service
-       |  $printedName import [-d,--draft] [-c,--continue] <inbox> <outbox>
-       |  $printedName import [-d,--draft] -s <single-deposit> <outbox>
+       |  $printedName import [-c,--continue] [--skip-validation] <inbox> <outbox>
+       |  $printedName import -s [--skip-validation] <single-deposit> <outbox>
        |  """.stripMargin
 
   version(s"$printedName v${ configuration.version }")
@@ -55,8 +55,8 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   val importCommand = new Subcommand("import") {
     descr("Imports one ore more deposits. Does not monitor for new deposits to arrive, but instead terminates after importing the batch.")
     val singleDeposit: ScallopOption[Boolean] = opt(name = "single", descr = "Single deposit instead of a deposits inbox")
-    val draft: ScallopOption[Boolean] = opt(name = "draft", descr = "Do not publish the resulting datasets, but keep them on DRAFT status")
     val continue: ScallopOption[Boolean] = opt(name = "continue", descr = "Continue previous import, suppress check for empty outbox.")
+    val skipValidation: ScallopOption[Boolean] = opt(name = "skip-validation", descr = "Skip calling easy-validate-dans-bag")
     val depositsInboxOrSingleDeposit: ScallopOption[Path] = trailArg(name = "inbox-or-single-deposit",
       descr = "Directory containing as sub-directories the deposit dirs to be imported or a single deposit")
     val outdir: ScallopOption[Path] = trailArg(name = "outdir", descr = "Directory where deposits are moved to after import.", required = true)

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTaskFactory.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTaskFactory.scala
@@ -26,7 +26,7 @@ import scala.xml.Elem
  *
  * @param isMigrated                                   is this a migrated dataset?
  * @param activeMetadataBlocks                         the metadata blocks enabled in the target dataverse
- * @param dansBagValidator                             interface to the easy-validate-dans-bag service
+ * @param optDansBagValidator                             interface to the easy-validate-dans-bag service
  * @param instance                                     interface to the target Dataverse instance
  * @param publishAwaitUnlockMaxNumberOfRetries         maximum number of times to poll for unlock after publish is called after ingest of the deposit
  * @param publishAwaitUnlockMillisecondsBetweenRetries number of milliseconds to wait between retries of unlock polling after publish
@@ -37,7 +37,7 @@ import scala.xml.Elem
  */
 class DepositIngestTaskFactory(isMigrated: Boolean = false,
                                activeMetadataBlocks: List[String],
-                               dansBagValidator: DansBagValidator,
+                               optDansBagValidator: Option[DansBagValidator],
                                instance: DataverseInstance,
                                publishAwaitUnlockMaxNumberOfRetries: Int,
                                publishAwaitUnlockMillisecondsBetweenRetries: Int,
@@ -50,7 +50,7 @@ class DepositIngestTaskFactory(isMigrated: Boolean = false,
     if (isMigrated)
       new DepositMigrationTask(deposit,
         activeMetadataBlocks,
-        dansBagValidator,
+        optDansBagValidator,
         instance,
         publishAwaitUnlockMaxNumberOfRetries,
         publishAwaitUnlockMillisecondsBetweenRetries,
@@ -62,7 +62,7 @@ class DepositIngestTaskFactory(isMigrated: Boolean = false,
     DepositIngestTask(
         deposit,
         activeMetadataBlocks,
-        dansBagValidator,
+        optDansBagValidator,
         instance,
         publishAwaitUnlockMaxNumberOfRetries,
         publishAwaitUnlockMillisecondsBetweenRetries,

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositMigrationTask.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositMigrationTask.scala
@@ -27,7 +27,7 @@ import scala.xml.{ Elem, Node }
 
 class DepositMigrationTask(deposit: Deposit,
                            activeMetadataBlocks: List[String],
-                           dansBagValidator: DansBagValidator,
+                           optDansBagValidator: Option[DansBagValidator],
                            instance: DataverseInstance,
                            publishAwaitUnlockMaxNumberOfRetries: Int,
                            publishAwaitUnlockMillisecondsBetweenRetries: Int,
@@ -35,16 +35,16 @@ class DepositMigrationTask(deposit: Deposit,
                            isoToDataverseLanguage: Map[String, String],
                            repordIdToTerm: Map[String, String],
                            outboxDir: File)
-  extends DepositIngestTask(deposit: Deposit,
-    activeMetadataBlocks: List[String],
-    dansBagValidator: DansBagValidator,
-    instance: DataverseInstance,
-    publishAwaitUnlockMaxNumberOfRetries: Int,
-    publishAwaitUnlockMillisecondsBetweenRetries: Int,
-    narcisClassification: Elem,
-    isoToDataverseLanguage: Map[String, String],
-    repordIdToTerm: Map[String, String],
-    outboxDir: File) {
+  extends DepositIngestTask(deposit,
+    activeMetadataBlocks,
+    optDansBagValidator,
+    instance,
+    publishAwaitUnlockMaxNumberOfRetries,
+    publishAwaitUnlockMillisecondsBetweenRetries,
+    narcisClassification,
+    isoToDataverseLanguage,
+    repordIdToTerm,
+    outboxDir) {
 
   override protected def checkDepositType(): Try[Unit] = {
     for {


### PR DESCRIPTION
NO JIRA.

# Description of changes
* Added option `--skip-validation` to the `import` subcommand. This will cause the call to `easy-validate-dans-bag` to be skipped. At the time of writing the immediate need for this is due to a test export that turns out not to validate, but can still be imported. In the longer run this may still be a useful feature. You could do an export, prevalidate it and then skip validation during import.
* Corrected some docs.
* Removed the `--draft` option, which allowed you to import a dataset and keep it on draft. This does not seem useful for the migration in retrospect.
* Made the `inboxWatcher` field on the App object lazy. This prevents the program from trying to create the outbox dirs for the *service* when doing an `import` (which results in a permission denied, because the user calling `import` has not permissions to create the directories at that location).
* Implemented skip-validation by making the `dansBagValidator` object an option.

# How to test


# Related PRs 
(Add links)
* 

# Notify
@DANS-KNAW/dataversedans
