### PR TITLE
DD-472 Implement mapping of file accessibility

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -102,6 +102,16 @@ From `<bag>/metadata/files.xml` the corresponding `<file>` element is looked up:
     `REQUEST_PERMISSION`     |  Yes
     `OPEN_ACCESS`            |  No
 
+##### Permission requests
+In Dataverse permission requests can be enabled only at the dataset level. It is not possible to allow permission requests for
+one file and disallow them for another file in the same dataset (even if the two files are in different versions). The following
+rule will be applied to enabled or disable permission requests:
+
+*If one or more files in the dataset (in any of its version) have an (effective) accessibility of `NONE`, permission requests will
+be disabled; otherwise they will be enabled.* 
+
+Note that it is therefore possible for an update deposit to disable permission requests on a dataset, but not to enable them.
+
 ARGUMENTS
 ---------
 

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-dataverse-scala-lib_2.12</artifactId>
-            <version>3.2.1-SNAPSHOT</version>
+            <version>3.2.1</version>
         </dependency>
         <dependency>
             <groupId>org.scalaj</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-dataverse-scala-lib_2.12</artifactId>
-            <version>3.2.0</version>
+            <version>3.2.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.scalaj</groupId>

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetUpdater.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetUpdater.scala
@@ -67,6 +67,11 @@ class DatasetUpdater(deposit: Deposit, isMigration: Boolean = false, metadataBlo
       // TODO: what happens with file that only got a new description? Their MD will not be updated ??!!
       // TODO: probably just change this to: update the file md of all the files that are in the new version. Will DV show "null-replacements" in the differences view??
       _ <- updateFileMetadata(fileReplacements ++ fileMovements ++ fileAdditions)
+      _ <- instance.dataset(doi).awaitUnlock()
+      /*
+       * Cannot enable requests if they were disallowed because of closed files in a previous version. However disabling is possible because a the update may add a closed file.
+       */
+      _ <- configureEnableAccessRequests(deposit, doi, canEnable = false)
     } yield doi
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTask.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTask.scala
@@ -18,7 +18,7 @@ package nl.knaw.dans.easy.dd2d
 import better.files.File
 import nl.knaw.dans.easy.dd2d.OutboxSubdir.{ FAILED, OutboxSubdir, PROCESSED, REJECTED }
 import nl.knaw.dans.easy.dd2d.dansbag.{ DansBagValidationResult, DansBagValidator }
-import nl.knaw.dans.easy.dd2d.mapping.JsonObject
+import nl.knaw.dans.easy.dd2d.mapping.{ AccessRights, JsonObject }
 import nl.knaw.dans.lib.dataverse.DataverseInstance
 import nl.knaw.dans.lib.dataverse.model.dataset.UpdateType.major
 import nl.knaw.dans.lib.dataverse.model.dataset.{ Dataset, PrimitiveSingleValueField, toFieldMap }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/AccessRights.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/AccessRights.scala
@@ -27,4 +27,24 @@ object AccessRights {
   def toDefaultRestrict(node: Node): Boolean = {
     accessRightsToDefaultRestrict.getOrElse(node.text, true)
   }
+
+  def isEnableRequests(accessRightsNode: Node, filesNode: Node): Boolean = {
+    val explicitAccessibleToValues = filesNode \ "file" \ "accessibleTo"
+    val numberOfFiles = (filesNode \ "file").size
+
+    def isExplicitlyDefinedNoAccessFilePresent = {
+      explicitAccessibleToValues.map(_.text).contains("NO_ACCESS")
+    }
+
+    def isImplicitlyDefinedNoAccessFilePresent = {
+      numberOfFiles > explicitAccessibleToValues.size && accessRightsNode.text == "NONE"
+    }
+
+    /*
+     * If one or more files are explicitly fully closed, the complete dataset must be not allow permission requests.
+     * If there are implicitly defined accessibleTo values the access category must not be NONE, because that means
+     * the implicit accessibleTo is NO_ACCESS. See: https://dans-knaw.github.io/dans-bagit-profile/versions/0.0.0/#4-bag-sequence-requirements
+     */
+    !isExplicitlyDefinedNoAccessFilePresent && !isImplicitlyDefinedNoAccessFilePresent
+  }
 }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/AccessRights.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/AccessRights.scala
@@ -29,7 +29,7 @@ object AccessRights {
   }
 
   def isEnableRequests(accessRightsNode: Node, filesNode: Node): Boolean = {
-    val explicitAccessibleToValues = filesNode \ "file" \ "accessibleTo"
+    val explicitAccessibleToValues = filesNode \ "file" \ "accessibleToRights"
     val numberOfFiles = (filesNode \ "file").size
 
     def isExplicitlyDefinedNoAccessFilePresent = {

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/AccessRights.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/AccessRights.scala
@@ -33,11 +33,11 @@ object AccessRights {
     val numberOfFiles = (filesNode \ "file").size
 
     def isExplicitlyDefinedNoAccessFilePresent = {
-      explicitAccessibleToValues.map(_.text).contains("NO_ACCESS")
+      explicitAccessibleToValues.map(_.text).contains("NONE")
     }
 
     def isImplicitlyDefinedNoAccessFilePresent = {
-      numberOfFiles > explicitAccessibleToValues.size && accessRightsNode.text == "NONE"
+      numberOfFiles > explicitAccessibleToValues.size && accessRightsNode.text == "NO_ACCESS"
     }
 
     /*

--- a/src/test/scala/nl.knaw.dans.easy.dd2d/mapping/AccessRightsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.dd2d/mapping/AccessRightsSpec.scala
@@ -16,7 +16,7 @@
 package nl.knaw.dans.easy.dd2d.mapping
 
 import nl.knaw.dans.easy.dd2d.TestSupportFixture
-import nl.knaw.dans.easy.dd2d.mapping.AccessRights.toDefaultRestrict
+import nl.knaw.dans.easy.dd2d.mapping.AccessRights.{ isEnableRequests, toDefaultRestrict }
 
 class AccessRightsSpec extends TestSupportFixture {
 
@@ -44,4 +44,79 @@ class AccessRightsSpec extends TestSupportFixture {
     val accessRights = <ddm:accessRights>SOMETHING</ddm:accessRights>
     toDefaultRestrict(accessRights) shouldBe true
   }
+
+  "isEnableRequests" should "be false if one file has explicitly accessibleTo == NONE" in {
+    val accessRights = <ddm:accessRights>OPEN_ACCESS</ddm:accessRights>
+    val files = <files>
+      <file filepath="path/to/file1">
+        <!-- No explicit accessibleTo -->
+      </file>
+      <file filepath="path/to/file2">
+        <ddm:accessibleTo>ANONYMOUS</ddm:accessibleTo>
+      </file>
+      <file filepath="path/to/file2">
+        <ddm:accessibleTo>NONE</ddm:accessibleTo>
+      </file>
+      <file filepath="path/to/file3">
+        <ddm:accessibleTo>NONE</ddm:accessibleTo>
+      </file>
+    </files>
+
+    isEnableRequests(accessRights, files) shouldBe false
+  }
+
+  it should "be false if one file has implicitly accessibleTo == NONE" in {
+    val accessRights = <ddm:accessRights>NO_ACCESS</ddm:accessRights>
+    val files = <files>
+      <file filepath="path/to/file1">
+        <!-- No explicit accessibleTo but default for access category is NONE -->
+      </file>
+      <file filepath="path/to/file2">
+        <ddm:accessibleTo>ANONYMOUS</ddm:accessibleTo>
+      </file>
+    </files>
+
+    isEnableRequests(accessRights, files) shouldBe false
+  }
+
+  it should "be true if all files explicitly permission request" in {
+    val accessRights = <ddm:accessRights>NO_ACCESS</ddm:accessRights>
+    val files = <files>
+      <file filepath="path/to/file1">
+        <ddm:accessibleTo>RESTRICTED_REQUEST</ddm:accessibleTo>
+      </file>
+      <file filepath="path/to/file2">
+        <ddm:accessibleTo>RESTRICTED_REQUEST</ddm:accessibleTo>
+      </file>
+      <file filepath="path/to/file2">
+        <ddm:accessibleTo>RESTRICTED_REQUEST</ddm:accessibleTo>
+      </file>
+      <file filepath="path/to/file3">
+        <ddm:accessibleTo>RESTRICTED_REQUEST</ddm:accessibleTo>
+      </file>
+    </files>
+
+    isEnableRequests(accessRights, files) shouldBe true
+  }
+
+  it should "be true if all implicitly and explicitly defined accessibleTo is RESTRICTED_REQUEST or more open" in {
+    val accessRights = <ddm:accessRights>REQUEST_PERMISSION</ddm:accessRights>
+    val files = <files>
+      <file filepath="path/to/file1">
+        <ddm:accessibleTo>RESTRICTED_REQUEST</ddm:accessibleTo>
+      </file>
+      <file filepath="path/to/file2">
+        <ddm:accessibleTo>RESTRICTED_REQUEST</ddm:accessibleTo>
+      </file>
+      <file filepath="path/to/file2">
+        <ddm:accessibleTo>RESTRICTED_REQUEST</ddm:accessibleTo>
+      </file>
+      <file filepath="path/to/file3">
+        <!-- Implicitly also -RESTRICTED_REQUEST -->
+      </file>
+    </files>
+
+    isEnableRequests(accessRights, files) shouldBe true
+  }
+
 }

--- a/src/test/scala/nl.knaw.dans.easy.dd2d/mapping/AccessRightsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.dd2d/mapping/AccessRightsSpec.scala
@@ -52,13 +52,13 @@ class AccessRightsSpec extends TestSupportFixture {
         <!-- No explicit accessibleTo -->
       </file>
       <file filepath="path/to/file2">
-        <ddm:accessibleTo>ANONYMOUS</ddm:accessibleTo>
+        <ddm:accessibleToRights>ANONYMOUS</ddm:accessibleToRights>
       </file>
       <file filepath="path/to/file2">
-        <ddm:accessibleTo>NONE</ddm:accessibleTo>
+        <ddm:accessibleToRights>NONE</ddm:accessibleToRights>
       </file>
       <file filepath="path/to/file3">
-        <ddm:accessibleTo>NONE</ddm:accessibleTo>
+        <ddm:accessibleToRights>NONE</ddm:accessibleToRights>
       </file>
     </files>
 
@@ -72,7 +72,7 @@ class AccessRightsSpec extends TestSupportFixture {
         <!-- No explicit accessibleTo but default for access category is NONE -->
       </file>
       <file filepath="path/to/file2">
-        <ddm:accessibleTo>ANONYMOUS</ddm:accessibleTo>
+        <ddm:accessibleToRights>ANONYMOUS</ddm:accessibleToRights>
       </file>
     </files>
 
@@ -83,16 +83,16 @@ class AccessRightsSpec extends TestSupportFixture {
     val accessRights = <ddm:accessRights>NO_ACCESS</ddm:accessRights>
     val files = <files>
       <file filepath="path/to/file1">
-        <ddm:accessibleTo>RESTRICTED_REQUEST</ddm:accessibleTo>
+        <ddm:accessibleToRights>RESTRICTED_REQUEST</ddm:accessibleToRights>
       </file>
       <file filepath="path/to/file2">
-        <ddm:accessibleTo>RESTRICTED_REQUEST</ddm:accessibleTo>
+        <ddm:accessibleToRights>RESTRICTED_REQUEST</ddm:accessibleToRights>
       </file>
       <file filepath="path/to/file2">
-        <ddm:accessibleTo>RESTRICTED_REQUEST</ddm:accessibleTo>
+        <ddm:accessibleToRights>RESTRICTED_REQUEST</ddm:accessibleToRights>
       </file>
       <file filepath="path/to/file3">
-        <ddm:accessibleTo>RESTRICTED_REQUEST</ddm:accessibleTo>
+        <ddm:accessibleToRights>RESTRICTED_REQUEST</ddm:accessibleToRights>
       </file>
     </files>
 
@@ -103,13 +103,13 @@ class AccessRightsSpec extends TestSupportFixture {
     val accessRights = <ddm:accessRights>REQUEST_PERMISSION</ddm:accessRights>
     val files = <files>
       <file filepath="path/to/file1">
-        <ddm:accessibleTo>RESTRICTED_REQUEST</ddm:accessibleTo>
+        <ddm:accessibleToRights>RESTRICTED_REQUEST</ddm:accessibleToRights>
       </file>
       <file filepath="path/to/file2">
-        <ddm:accessibleTo>RESTRICTED_REQUEST</ddm:accessibleTo>
+        <ddm:accessibleToRights>RESTRICTED_REQUEST</ddm:accessibleToRights>
       </file>
       <file filepath="path/to/file2">
-        <ddm:accessibleTo>RESTRICTED_REQUEST</ddm:accessibleTo>
+        <ddm:accessibleToRights>RESTRICTED_REQUEST</ddm:accessibleToRights>
       </file>
       <file filepath="path/to/file3">
         <!-- Implicitly also -RESTRICTED_REQUEST -->

--- a/src/test/scala/nl.knaw.dans.easy.dd2d/mapping/AccessRightsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.dd2d/mapping/AccessRightsSpec.scala
@@ -44,5 +44,4 @@ class AccessRightsSpec extends TestSupportFixture {
     val accessRights = <ddm:accessRights>SOMETHING</ddm:accessRights>
     toDefaultRestrict(accessRights) shouldBe true
   }
-
 }


### PR DESCRIPTION
Fixes DD-472

# Description of changes
Implemented the following rule (from the docs site):

> *If one or more files in the dataset (in any of its version) have an (effective) accessibility of `NONE`, permission requests will be disabled; otherwise they will be enabled.* 

I was not sure if files always have explicit declarations of their accessibleToRights. For the behavior to work it should not be necessary. The access category of the dataset will be used to find the effective accessibleToRights if it is omitted.

# How to test
This can be tested by creating deposits with various combinations of file accessiblities and categories. The unit tests in `nl.knaw.dans.easy.dd2d.mapping.AccessRightsSpec` should cover most cases. However the unit tests do not cover the rule that an update deposit can only **remove** the "allow permission requests" setting and not add it. The rationale is that there are fully closed files in already published versions which should block any attempt to automatically allowing future permission requests. (It could still be done through the Access API or manually, of course).

# Related PRs 
* https://github.com/DANS-KNAW/dans-dataverse-scala-lib/pull/14

# Notify
@DANS-KNAW/dataversedans
