### PR TITLE
DD-518. SWORD2 update-deposit fails because SWORD-token cannot be found in index

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetUpdater.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetUpdater.scala
@@ -78,9 +78,8 @@ class DatasetUpdater(deposit: Deposit, isMigration: Boolean = false, metadataBlo
   private def getDoiBySwordToken: Try[String] = {
     trace(())
     debug(s"dansSwordToken = ${ deposit.vaultMetadata.dataverseSwordToken }")
-    val Array(_, swordTokenUuid) = deposit.vaultMetadata.dataverseSwordToken.split(":")
     for {
-      r <- instance.search().find(s"""dansSwordToken:"$swordTokenUuid"""")
+      r <- instance.search().find(s"""dansSwordToken:"${deposit.vaultMetadata.dataverseSwordToken}"""")
       searchResult <- r.data
       items = searchResult.items
       _ = if (items.size != 1) throw FailedDepositException(deposit, s"Deposit is update of ${ items.size } datasets; should always be 1!")


### PR DESCRIPTION
Fixes DD-518

# Description of changes
Because of the problem described in DD-518 occasionally popping up `dd-dans-deposit-to-dataverse` searched only on the UUID-part of `dansSwordToken` when trying to find the target of an update-deposit. The resolution in https://github.com/DANS-KNAW/dd-dtap/pull/120 means that searches for the SWORD token must now specify the full token, including the `sword:` prefix.

# How to test
* Try and update deposit.


# Related PRs 
* https://github.com/DANS-KNAW/dd-dtap/pull/120

# Notify
@DANS-KNAW/dataversedans
