### PR TITLE
DD-560 easy-migration directoryLabel lost in second version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-dataverse-scala-lib_2.12</artifactId>
-            <version>4.0.0</version>
+            <version>4.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.scalaj</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-dataverse-scala-lib_2.12</artifactId>
-            <version>4.0.1-SNAPSHOT</version>
+            <version>4.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.scalaj</groupId>

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -2,12 +2,12 @@
 # Where to look for deposits and what to do with them
 #
 deposits.inbox=
-deposits.outbox=/var/opt/dans.knaw.nl/tmp/deposits-outbox
+deposits.outbox=
 
 #
-# Filtering
+# Filtering. Files with a path matching the pattern will not be added to the dataset. Renaming/moving files is not affected.
 #
-deposits.file-exclusion-pattern=^.*thumbnails/.*_small\.(jpg|png|tif)$
+deposits.file-exclusion-pattern=^$
 
 #
 # Parameters related to communication with the Dataverse instance

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -5,13 +5,17 @@ deposits.inbox=
 deposits.outbox=/var/opt/dans.knaw.nl/tmp/deposits-outbox
 
 #
+# Filtering
+#
+deposits.file-exclusion-pattern=^.*thumbnails/.*_small\.(jpg|png|tif)$
+
+#
 # Parameters related to communication with the Dataverse instance
 #
 dataverse.base-url=
 dataverse.api-version=1
 dataverse.connection-timeout-ms=10000
 dataverse.read-timeout-ms=30000
-# TODO: API key should be connected to user that is doing the request
 dataverse.api-key=
 # Only use for testing purposes and never in production!
 #dataverse.admin-api-unblock-key=

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/Configuration.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/Configuration.scala
@@ -25,6 +25,7 @@ import org.apache.commons.csv.{ CSVFormat, CSVParser }
 import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.nio.file.{ Path, Paths }
+import java.util.regex.Pattern
 import scala.collection.JavaConverters.asScalaIteratorConverter
 import scala.util.Try
 import scala.xml.{ Elem, XML }
@@ -32,6 +33,7 @@ import scala.xml.{ Elem, XML }
 case class Configuration(version: String,
                          inboxDir: File,
                          outboxDir: Path,
+                         optFileExclusionPattern: Option[Pattern],
                          validatorServiceUrl: URI,
                          validatorConnectionTimeoutMs: Int,
                          validatorReadTimeoutMs: Int,
@@ -76,6 +78,7 @@ object Configuration {
       version = (home / "bin" / "version").contentAsString.stripLineEnd,
       inboxDir = File(properties.getString("deposits.inbox")),
       outboxDir = Paths.get(properties.getString("deposits.outbox")),
+      optFileExclusionPattern = Option(properties.getString("deposits.file-exclusion-pattern")).map(Pattern.compile),
       validatorServiceUrl = new URI(properties.getString("validate-dans-bag.service-url")),
       validatorConnectionTimeoutMs = properties.getInt("validate-dans-bag.connection-timeout-ms"),
       validatorReadTimeoutMs = properties.getInt("validate-dans-bag.read-timeout-ms"),

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DansDepositToDataverseApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DansDepositToDataverseApp.scala
@@ -38,6 +38,7 @@ class DansDepositToDataverseApp(configuration: Configuration) extends DebugEnhan
     new InboxWatcher(new Inbox(configuration.inboxDir,
       new DepositIngestTaskFactory(
         isMigrated = false,
+        configuration.optFileExclusionPattern,
         getActiveMetadataBlocks.get,
         Option(dansBagValidator),
         dataverse,
@@ -68,6 +69,7 @@ class DansDepositToDataverseApp(configuration: Configuration) extends DebugEnhan
       _ <- new SingleDepositProcessor(deposit,
         new DepositIngestTaskFactory(
           isMigrated = true,
+          configuration.optFileExclusionPattern,
           getActiveMetadataBlocks.get,
           if (skipValidation) Option.empty
           else Option(dansBagValidator),
@@ -91,6 +93,7 @@ class DansDepositToDataverseApp(configuration: Configuration) extends DebugEnhan
       _ <- new InboxProcessor(new Inbox(inbox,
         new DepositIngestTaskFactory(
           isMigrated = true,
+          configuration.optFileExclusionPattern,
           getActiveMetadataBlocks.get,
           if (skipValidation) Option.empty
           else Option(dansBagValidator),

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTask.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTask.scala
@@ -30,6 +30,7 @@ import org.json4s.native.Serialization
 import org.json4s.{ DefaultFormats, Formats }
 
 import java.lang.Thread.sleep
+import java.util.regex.Pattern
 import scala.collection.mutable.ListBuffer
 import scala.language.postfixOps
 import scala.util.control.NonFatal
@@ -43,6 +44,7 @@ import scala.xml.Elem
  * @param instance the Dataverse instance to ingest in
  */
 case class DepositIngestTask(deposit: Deposit,
+                             optFileExclusionPattern: Option[Pattern],
                              activeMetadataBlocks: List[String],
                              optDansBagValidator: Option[DansBagValidator],
                              instance: DataverseInstance,
@@ -168,11 +170,11 @@ case class DepositIngestTask(deposit: Deposit,
   }
 
   protected def newDatasetUpdater(dataverseDataset: Dataset): DatasetUpdater = {
-    new DatasetUpdater(deposit, isMigration = false, dataverseDataset.datasetVersion.metadataBlocks, instance, Option.empty)
+    new DatasetUpdater(deposit, optFileExclusionPattern, isMigration = false, dataverseDataset.datasetVersion.metadataBlocks, instance, Option.empty)
   }
 
   protected def newDatasetCreator(dataverseDataset: Dataset): DatasetCreator = {
-    new DatasetCreator(deposit, isMigration = false, dataverseDataset, instance, Option.empty)
+    new DatasetCreator(deposit, optFileExclusionPattern, isMigration = false, dataverseDataset, instance, Option.empty)
   }
 
   protected def publishDataset(persistentId: String): Try[Unit] = {

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTaskFactory.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositIngestTaskFactory.scala
@@ -20,6 +20,7 @@ import nl.knaw.dans.easy.dd2d.dansbag.DansBagValidator
 import nl.knaw.dans.easy.dd2d.migrationinfo.MigrationInfo
 import nl.knaw.dans.lib.dataverse.DataverseInstance
 
+import java.util.regex.Pattern
 import scala.xml.Elem
 
 /**
@@ -38,6 +39,7 @@ import scala.xml.Elem
  * @param outboxDir                                    outbox
  */
 class DepositIngestTaskFactory(isMigrated: Boolean = false,
+                               optFileExclusionPattern: Option[Pattern],
                                activeMetadataBlocks: List[String],
                                optDansBagValidator: Option[DansBagValidator],
                                instance: DataverseInstance,
@@ -53,6 +55,7 @@ class DepositIngestTaskFactory(isMigrated: Boolean = false,
   def createDepositIngestTask(deposit: Deposit): DepositIngestTask = {
     if (isMigrated)
       new DepositMigrationTask(deposit,
+        optFileExclusionPattern,
         activeMetadataBlocks,
         optDansBagValidator,
         instance,
@@ -67,6 +70,7 @@ class DepositIngestTaskFactory(isMigrated: Boolean = false,
     else
       DepositIngestTask(
         deposit,
+        optFileExclusionPattern,
         activeMetadataBlocks,
         optDansBagValidator,
         instance,

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositMigrationTask.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositMigrationTask.scala
@@ -22,11 +22,13 @@ import nl.knaw.dans.easy.dd2d.migrationinfo.MigrationInfo
 import nl.knaw.dans.lib.dataverse.DataverseInstance
 import nl.knaw.dans.lib.dataverse.model.dataset.Dataset
 
+import java.util.regex.Pattern
 import scala.language.postfixOps
 import scala.util.{ Failure, Success, Try }
 import scala.xml.{ Elem, Node }
 
 class DepositMigrationTask(deposit: Deposit,
+                           optFileExclusionPattern: Option[Pattern],
                            activeMetadataBlocks: List[String],
                            optDansBagValidator: Option[DansBagValidator],
                            instance: DataverseInstance,
@@ -39,6 +41,7 @@ class DepositMigrationTask(deposit: Deposit,
                            repordIdToTerm: Map[String, String],
                            outboxDir: File)
   extends DepositIngestTask(deposit,
+    optFileExclusionPattern,
     activeMetadataBlocks,
     optDansBagValidator,
     instance,
@@ -60,11 +63,11 @@ class DepositMigrationTask(deposit: Deposit,
   }
 
   override def newDatasetUpdater(dataverseDataset: Dataset): DatasetUpdater = {
-    new DatasetUpdater(deposit, isMigration = true, dataverseDataset.datasetVersion.metadataBlocks, instance, migrationInfo)
+    new DatasetUpdater(deposit, optFileExclusionPattern, isMigration = true, dataverseDataset.datasetVersion.metadataBlocks, instance, migrationInfo)
   }
 
   override def newDatasetCreator(dataverseDataset: Dataset): DatasetCreator = {
-    new DatasetCreator(deposit, isMigration = true, dataverseDataset, instance, migrationInfo)
+    new DatasetCreator(deposit, optFileExclusionPattern, isMigration = true, dataverseDataset, instance, migrationInfo)
   }
 
   override protected def getDateOfDeposit: Try[Option[String]] = {

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -5,6 +5,11 @@ deposits.inbox=data/inbox/
 deposits.outbox=/var/opt/dans.knaw.nl/tmp/outbox
 
 #
+# Filtering
+#
+deposits.file-exclusion-pattern=^.*thumbnails/.*_small\.(jpg|png|tif)$
+
+#
 # Parameters related to communication with the Dataverse instance
 #
 dataverse.base-url=https://ddd.dans.knaw.nl/

--- a/src/test/scala/nl.knaw.dans.easy.dd2d/IndexSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.dd2d/IndexSpec.scala
@@ -26,6 +26,7 @@ class IndexSpec extends TestSupportFixture {
     version = "my-version",
     inboxDir = null,
     outboxDir = null,
+    optFileExclusionPattern = null,
     validatorServiceUrl = null,
     validatorConnectionTimeoutMs = 1000,
     validatorReadTimeoutMs = 1000,


### PR DESCRIPTION
Fixes DD-560 and DD-547

# Description of changes
* Make sure the correct file metadata is passed for updating replaced files' metadata.
* Make sure file metadata is also replaced for files that do not change otherwise.
* Adds a setting `deposits.file-exclusion-pattern`. The value must be a valid regular expression. Files of which the path relative to the `data/` folder of their parent bag matches the pattern are excluded from the import. An info message is logged to notify the user calling import.

# How to test
See related PR.

# Related PRs 
* https://github.com/DANS-KNAW/dd-dtap/pull/129

# Notify
@DANS-KNAW/dataversedans
