### PR TITLE
DD-645 Make depositor of automated deposit Contributor instead of Curator of created dataset

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetCreator.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetCreator.scala
@@ -49,7 +49,7 @@ class DatasetCreator(deposit: Deposit,
       _ <- configureEnableAccessRequests(deposit, persistentId, canEnable = true)
       _ <- instance.dataset(persistentId).awaitUnlock()
       _ = debug(s"Assigning curator role to ${ deposit.depositorUserId }")
-      _ <- instance.dataset(persistentId).assignRole(RoleAssignment(s"@${ deposit.depositorUserId }", DefaultRole.curator.toString))
+      _ <- instance.dataset(persistentId).assignRole(RoleAssignment(s"@${ deposit.depositorUserId }", DefaultRole.contributor.toString))
       _ <- instance.dataset(persistentId).awaitUnlock()
     } yield persistentId
   }


### PR DESCRIPTION
Fixes DD-645

# Description of changes
* Changed the role assignment. The assigned role remained hard-coded for now. It should probably become configurable later.


# How to test
* Create a dataset via `import` or via the SWORD2 service and check the role of the depositor account on the created dataset.


# Notify
@DANS-KNAW/dataversedans
