### PR TITLE
DD-659. deposit-to-dataverse must use pre-staged.csv to get checksums of pruned files

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/Configuration.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/Configuration.scala
@@ -109,18 +109,4 @@ object Configuration {
     if (url.endsWith("/")) url
     else url + "/"
   }
-
-  def loadCsvToMap(csvFile: File, keyColumn: String, valueColumn: String): Try[Map[String, String]] = {
-    import resource.managed
-
-    def csvParse(csvParser: CSVParser): Map[String, String] = {
-      csvParser.iterator().asScala
-        .map { r => (r.get(keyColumn), r.get(valueColumn)) }.toMap
-    }
-
-    managed(CSVParser.parse(
-      csvFile.toJava,
-      StandardCharsets.UTF_8,
-      CSVFormat.RFC4180.withFirstRecordAsHeader())).map(csvParse).tried
-  }
 }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/Deposit.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/Deposit.scala
@@ -87,12 +87,22 @@ case class Deposit(dir: File) extends DebugEnhancedLogging {
     case t: Throwable => Failure(new IllegalArgumentException(s"Unparseable XML: ${ t.getMessage }"))
   }
 
+  lazy val tryOptPrestagedCsv: Try[Option[Map[Path, String]]] = {
+    val prestagedFile = bagDir / "metadata" / "pre-staged.csv"
+    if (prestagedFile.exists) {
+      loadCsvToMap(prestagedFile, "path", "checksum")
+        .map(_.map { case (k, v) => Paths.get(k) -> v }).map(Option.apply)
+    }
+    else Try(None)
+  }
+
   lazy val tryFilePathToSha1: Try[Map[Path, String]] = {
     for {
       bag <- tryBag
       optSha1Manifest = bag.getPayLoadManifests.asScala.find(_.getAlgorithm == StandardSupportedAlgorithms.SHA1)
       _ = if (optSha1Manifest.isEmpty) throw new IllegalArgumentException("Deposit bag does not have SHA-1 payload manifest")
-      result = optSha1Manifest.get.getFileToChecksumMap.asScala.map { case (p, c) => (bagDir.path relativize p, c) }.toMap
+      optPrestagedCsv <- tryOptPrestagedCsv
+      result = optSha1Manifest.get.getFileToChecksumMap.asScala.map { case (p, c) => (bagDir.path relativize p, c) }.toMap ++ optPrestagedCsv.getOrElse(Map.empty) // TODO: add check for overlapping keys?
     } yield result
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/package.scala
@@ -17,8 +17,11 @@ package nl.knaw.dans.easy
 
 import better.files.File
 import nl.knaw.dans.lib.dataverse.model.file.FileMeta
+import org.apache.commons.csv.{ CSVFormat, CSVParser }
 import org.apache.commons.lang.StringUtils
 
+import java.nio.charset.StandardCharsets
+import scala.collection.JavaConverters.asScalaIteratorConverter
 import scala.collection.mutable
 import scala.util.{ Failure, Success, Try }
 
@@ -66,5 +69,19 @@ package object dd2d {
     val PROCESSED = Value("processed")
     val REJECTED = Value("rejected")
     val FAILED = Value("failed")
+  }
+
+  def loadCsvToMap(csvFile: File, keyColumn: String, valueColumn: String): Try[Map[String, String]] = {
+    import resource.managed
+
+    def csvParse(csvParser: CSVParser): Map[String, String] = {
+      csvParser.iterator().asScala
+        .map { r => (r.get(keyColumn), r.get(valueColumn)) }.toMap
+    }
+
+    managed(CSVParser.parse(
+      csvFile.toJava,
+      StandardCharsets.UTF_8,
+      CSVFormat.RFC4180.withFirstRecordAsHeader())).map(csvParse).tried
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.dd2d/mapping/LanguageSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.dd2d/mapping/LanguageSpec.scala
@@ -17,17 +17,17 @@ package nl.knaw.dans.easy.dd2d.mapping
 
 import better.files.File
 import nl.knaw.dans.easy.dd2d.mapping.Language.toCitationBlockLanguage
-import nl.knaw.dans.easy.dd2d.{ Configuration, TestSupportFixture }
+import nl.knaw.dans.easy.dd2d.{ Configuration, TestSupportFixture, loadCsvToMap }
 
 import java.nio.file.Paths
 
 class LanguageSpec extends TestSupportFixture {
-  private val iso1ToDataverseLanguage = Configuration
-    .loadCsvToMap(File(Paths.get("src/main/assembly/dist/install/iso639-1-to-dv.csv").toAbsolutePath),
+  private val iso1ToDataverseLanguage =
+    loadCsvToMap(File(Paths.get("src/main/assembly/dist/install/iso639-1-to-dv.csv").toAbsolutePath),
       keyColumn = "ISO639-1",
       valueColumn = "Dataverse-language").get
-  private val iso2ToDataverseLanguage = Configuration
-    .loadCsvToMap(File(Paths.get("src/main/assembly/dist/install/iso639-2-to-dv.csv").toAbsolutePath),
+  private val iso2ToDataverseLanguage =
+    loadCsvToMap(File(Paths.get("src/main/assembly/dist/install/iso639-2-to-dv.csv").toAbsolutePath),
       keyColumn = "ISO639-2",
       valueColumn = "Dataverse-language").get
 


### PR DESCRIPTION
Fixes DD-659

# Description of changes
* The file `pre-staged.csv`, if present, is used to supplement the map from filepath to checksum.

# How to test
* Import a deposit that was pruned from pre-staged files with `easy-convert-bag-to-deposit -p`.



# Notify
@DANS-KNAW/dataversedans
