### PR TITLE
DD-651, put Y coord first in lon/lat field

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Spatial.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Spatial.scala
@@ -27,23 +27,23 @@ trait Spatial {
   val RD_SRS_NAME = "http://www.opengis.net/def/crs/EPSG/0/28992"
 
   val RD_SCHEME = "RD (in m.)"
-  val LATLON_SCHEME = "latitude/longitude (degrees)"
+  val LONLAT_SCHEME = "longitude/latitude (degrees)"
 
   case class Point(x: String, y: String)
 
   protected def isRd(env: Node): Boolean = {
-    // Not specifying a namespace in the attribut lookup because srsName is not recognized by the parser to be in the GML namespace,
+    // Not specifying a namespace in the attribute lookup because srsName is not recognized by the parser to be in the GML namespace,
     // even when the Envelope element has GML as its default namespace.
     env.attribute("srsName").exists(_.text == RD_SRS_NAME)
   }
 
-  protected def getPoint(p: Node): Point = {
+  protected def getPoint(isRd: Boolean)(p: Node): Point = {
     val cs = p.text.trim.split("""\s+""")
     // make sure that you have valid numbers here
     cs(0).toDouble
     cs(1).toDouble
 
-    if (isRd(p))
+    if (isRd)
       Point(cs(0), cs(1))
     else
     /*

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/SpatialBox.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/SpatialBox.scala
@@ -27,15 +27,15 @@ object SpatialBox extends Spatial with BlockTemporalAndSpatial {
    */
   def toEasyTsmSpatialBoxValueObject(boundedBy: Node): JsonObject = {
     val isRD = (boundedBy \ "Envelope").headOption.map(isRd).get // TODO: improve error handling
-    val lowerCorner = (boundedBy \ "Envelope" \ "lowerCorner").headOption.map(getPoint).get // TODO: improve error handling
-    val upperCorner = (boundedBy \ "Envelope" \ "upperCorner").headOption.map(getPoint).get // TODO: improve error handling
+    val lowerCorner = (boundedBy \ "Envelope" \ "lowerCorner").headOption.map(getPoint(isRD)).get // TODO: improve error handling
+    val upperCorner = (boundedBy \ "Envelope" \ "upperCorner").headOption.map(getPoint(isRD)).get // TODO: improve error handling
     val m = FieldMap()
     m.addCvField(SPATIAL_BOX_SCHEME, if (isRD) RD_SCHEME
-                                     else LATLON_SCHEME)
+                                     else LONLAT_SCHEME)
     m.addPrimitiveField(SPATIAL_BOX_NORTH, upperCorner.y)
-    m.addPrimitiveField(SPATIAL_BOX_EAST, lowerCorner.x)
+    m.addPrimitiveField(SPATIAL_BOX_EAST, upperCorner.x)
     m.addPrimitiveField(SPATIAL_BOX_SOUTH, lowerCorner.y)
-    m.addPrimitiveField(SPATIAL_BOX_WEST, upperCorner.x)
+    m.addPrimitiveField(SPATIAL_BOX_WEST, lowerCorner.x)
     m.toJsonObject
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/SpatialPoint.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/SpatialPoint.scala
@@ -22,11 +22,12 @@ object SpatialPoint extends Spatial with BlockTemporalAndSpatial {
     val isRD = isRd(spatial) // TODO: improve error handling
     // TODO: Only one Point expected here, but should be more robust
     val pointElem = (spatial \ "Point").head
-    val p = getPoint(pointElem)
+    // Passing in spatial to work around the fact that the point element does not have an srsName itself.
+    val p = getPoint(isRD)(pointElem)
     val m = FieldMap()
 
     m.addCvField(SPATIAL_POINT_SCHEME, if (isRD) RD_SCHEME
-                                       else LATLON_SCHEME)
+                                       else LONLAT_SCHEME)
     m.addPrimitiveField(SPATIAL_POINT_X, p.x)
     m.addPrimitiveField(SPATIAL_POINT_Y, p.y)
     m.toJsonObject

--- a/src/test/scala/nl.knaw.dans.easy.dd2d/mapping/SpatialBoxSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.dd2d/mapping/SpatialBoxSpec.scala
@@ -28,16 +28,16 @@ class SpatialBoxSpec extends TestSupportFixture with BlockTemporalAndSpatial {
     val spatialBox =
       <gml:boundedBy>
           <gml:Envelope>
-            <gml:lowerCorner>91232.015554 436172.485680</gml:lowerCorner>
-            <gml:upperCorner>121811.885272 486890.494251</gml:upperCorner>
+            <gml:lowerCorner>45.555 -100.666</gml:lowerCorner>
+            <gml:upperCorner>90.0 179.999</gml:upperCorner>
           </gml:Envelope>
       </gml:boundedBy>
     val result = Serialization.writePretty(SpatialBox.toEasyTsmSpatialBoxValueObject(spatialBox))
-    findString(result, s"$SPATIAL_BOX_SCHEME.value") shouldBe "latitude/longitude (degrees)"
-    findString(result, s"$SPATIAL_BOX_NORTH.value") shouldBe "486890.494251"
-    findString(result, s"$SPATIAL_BOX_EAST.value") shouldBe "91232.015554"
-    findString(result, s"$SPATIAL_BOX_SOUTH.value") shouldBe "436172.485680"
-    findString(result, s"$SPATIAL_BOX_WEST.value") shouldBe "121811.885272"
+    findString(result, s"$SPATIAL_BOX_SCHEME.value") shouldBe "longitude/latitude (degrees)"
+    findString(result, s"$SPATIAL_BOX_NORTH.value") shouldBe "90.0"
+    findString(result, s"$SPATIAL_BOX_EAST.value") shouldBe "179.999"
+    findString(result, s"$SPATIAL_BOX_SOUTH.value") shouldBe "45.555"
+    findString(result, s"$SPATIAL_BOX_WEST.value") shouldBe "-100.666"
   }
 
   it should "give 'RD (in m.)' as spatial box scheme" in {

--- a/src/test/scala/nl.knaw.dans.easy.dd2d/mapping/SpatialPointSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.dd2d/mapping/SpatialPointSpec.scala
@@ -21,7 +21,7 @@ import org.json4s.{ DefaultFormats, Formats }
 
 import scala.util.{ Failure, Try }
 
-class SpatialPointSpec extends TestSupportFixture with BlockTemporalAndSpatial {
+class SpatialPointSpec extends TestSupportFixture with BlockTemporalAndSpatial with Spatial {
   private implicit val jsonFormats: Formats = DefaultFormats
 
   "toEasyTsmSpatialPointValueObject" should "create correct spatial point details in Json object" in {
@@ -30,25 +30,25 @@ class SpatialPointSpec extends TestSupportFixture with BlockTemporalAndSpatial {
         <Point>52.08113 4.34510</Point>
       </spatial>
     val result = Serialization.writePretty(SpatialPoint.toEasyTsmSpatialPointValueObject(spatialPoint))
-    findString(result, s"$SPATIAL_POINT_SCHEME.value") shouldBe "latitude/longitude (degrees)"
-    findString(result, s"$SPATIAL_POINT_X.value") shouldBe "52.08113"
-    findString(result, s"$SPATIAL_POINT_Y.value") shouldBe "4.34510"
+    findString(result, s"$SPATIAL_POINT_SCHEME.value") shouldBe LONLAT_SCHEME
+    findString(result, s"$SPATIAL_POINT_X.value") shouldBe "4.34510"
+    findString(result, s"$SPATIAL_POINT_Y.value") shouldBe "52.08113"
   }
 
   it should "give 'RD (in m.)' as spatial point scheme and coordinates as integers" in {
     val spatialPoint =
-      <spatial srsName="http://www.opengis.net/def/crs/EPSG/0/28992">
+      <spatial srsName={RD_SRS_NAME}>
         <Point>469470 209942</Point>
       </spatial>
     val result = Serialization.writePretty(SpatialPoint.toEasyTsmSpatialPointValueObject(spatialPoint))
-    findString(result, s"$SPATIAL_POINT_SCHEME.value") shouldBe "RD (in m.)"
+    findString(result, s"$SPATIAL_POINT_SCHEME.value") shouldBe RD_SCHEME
     findString(result, s"$SPATIAL_POINT_X.value") shouldBe "469470"
     findString(result, s"$SPATIAL_POINT_Y.value") shouldBe "209942"
   }
 
   it should "throw exception when spatial point coordinates are given incorrectly" in {
     val spatialPoint =
-      <spatial srsName="http://www.opengis.net/def/crs/EPSG/0/28992">
+      <spatial srsName={RD_SRS_NAME}>
         <Point>52.08113, 4.34510</Point>
       </spatial>
     inside(Try(SpatialPoint.toEasyTsmSpatialPointValueObject(spatialPoint))) {


### PR DESCRIPTION
Fixes DD-651

# Description of changes
In a position value in a spatial element with srsName="http://www.opengis.net/def/crs/EPSG/0/4326" the Y-coordinate is put first. 

# Related PRs 
* https://github.com/DANS-KNAW/dd-dtap/pull/145

# Notify
@DANS-KNAW/dataversedans
