### PR TITLE
DD-700: Exclude easy-migration metadata files from embargo

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetCreator.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetCreator.scala
@@ -66,7 +66,7 @@ class DatasetCreator(deposit: Deposit,
           _ <- instance.dataset(persistentId).assignRole(RoleAssignment(s"@${ deposit.depositorUserId }", DefaultRole.contributor.toString))
           _ <- instance.dataset(persistentId).awaitUnlock()
           dateAvailable <- deposit.getDateAvailable
-          _ <- if (isEmbargo(dateAvailable)) embargoAllFiles(persistentId, dateAvailable)
+          _ <- if (isEmbargo(dateAvailable)) embargoFiles(persistentId, dateAvailable)
                else {
                  logger.debug(s"Date available in the past, no embargo: $dateAvailable")
                  Success(())
@@ -84,10 +84,10 @@ class DatasetCreator(deposit: Deposit,
     response.data.map(_.persistentId)
   }
 
-  private def embargoAllFiles(persistentId: PersistendId, dateAvailable: Date): Try[Unit] = {
-    logger.info(s"Putting embargo on all files until: $dateAvailable }")
+  private def embargoFiles(persistentId: PersistendId, dateAvailable: Date): Try[Unit] = {
+    logger.info(s"Putting embargo on files until: $dateAvailable")
     for {
-      files <- getAllFiles(persistentId)
+      files <- getFilesToEmbargo(persistentId)
       _ <- embargoFiles(persistentId, dateAvailable, files.map(_.dataFile.get.id))
       _ <- instance.dataset(persistentId).awaitUnlock()
     } yield ()

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetEditor.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetEditor.scala
@@ -133,11 +133,12 @@ abstract class DatasetEditor(instance: DataverseInstance, optFileExclusionPatter
     } yield ()
   }
 
-  protected def getAllFiles(persistendId: PersistendId): Try[List[FileMeta]] = {
+  protected def getFilesToEmbargo(persistendId: PersistendId): Try[List[FileMeta]] = {
     for {
       r <- instance.dataset(persistendId).listFiles()
       files <- r.data
-    } yield  files
+      filesToEmbargo = files.filter(f => f.directoryLabel.getOrElse(true).toString != "easy-migration")
+    } yield  filesToEmbargo
   }
 
   protected def isEmbargo(date: Date): Boolean = {

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetEditor.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetEditor.scala
@@ -137,7 +137,7 @@ abstract class DatasetEditor(instance: DataverseInstance, optFileExclusionPatter
     for {
       r <- instance.dataset(persistendId).listFiles()
       files <- r.data
-      filesToEmbargo = files.filter(f => f.directoryLabel.getOrElse(true).toString != "easy-migration")
+      filesToEmbargo = files.filter(f => f.directoryLabel.getOrElse("") != "easy-migration")
     } yield  filesToEmbargo
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetUpdater.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetUpdater.scala
@@ -97,8 +97,8 @@ class DatasetUpdater(deposit: Deposit,
 
           dateAvailable <- deposit.getDateAvailable
           _ <- if (isEmbargo(dateAvailable)) {
-            val fileIdsToEmbargo = fileReplacements.keys ++ fileAdditions.keys
-            logger.info(s"Embargoing new files until ${ dateAvailable }")
+            val fileIdsToEmbargo = (fileReplacements ++ fileAdditions).filter(f => f._2.directoryLabel.getOrElse(true).toString != "easy-migration").keys
+            logger.info(s"Embargoing new files until $dateAvailable")
             embargoFiles(doi, dateAvailable, fileIdsToEmbargo.toList)
           }
                else {

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetUpdater.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetUpdater.scala
@@ -97,7 +97,7 @@ class DatasetUpdater(deposit: Deposit,
 
           dateAvailable <- deposit.getDateAvailable
           _ <- if (isEmbargo(dateAvailable)) {
-            val fileIdsToEmbargo = (fileReplacements ++ fileAdditions).filter(f => f._2.directoryLabel.getOrElse(true).toString != "easy-migration").keys
+            val fileIdsToEmbargo = (fileReplacements ++ fileAdditions).filter(f => f._2.directoryLabel.getOrElse("") != "easy-migration").keys
             logger.info(s"Embargoing new files until $dateAvailable")
             embargoFiles(doi, dateAvailable, fileIdsToEmbargo.toList)
           }


### PR DESCRIPTION
Fixes DD-700

# Description of changes
files in `easy-migration` don't come under `embargo`

# How to test


# Related PRs 
(Add links)
* 

# Notify
@DANS-KNAW/dataversedans
