### PR TITLE
DD-615. Map publisher field

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositToDvDatasetMetadataMapper.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositToDvDatasetMetadataMapper.scala
@@ -92,6 +92,7 @@ class DepositToDvDatasetMetadataMapper(deduplicate: Boolean,
       addPrimitiveFieldSingleValue(citationFields, PRODUCTION_DATE, ddm \ "profile" \ "created", DateTypeElement toYearMonthDayFormat)
       addCompoundFieldMultipleValues(citationFields, CONTRIBUTOR, (ddm \ "dcmiMetadata" \ "contributorDetails" \ "author").filterNot(DcxDaiAuthor isRightsHolder), DcxDaiAuthor toContributorValueObject)
       addCompoundFieldMultipleValues(citationFields, CONTRIBUTOR, (ddm \ "dcmiMetadata" \ "contributorDetails" \ "organization").filterNot(DcxDaiOrganization isRightsHolder), DcxDaiOrganization toContributorValueObject)
+      addCompoundFieldMultipleValues(citationFields, DISTRIBUTOR, ddm \ "dcmiMetadata" \ "publisher",  Publisher toDistributorValueObject)
       addPrimitiveFieldSingleValue(citationFields, DISTRIBUTION_DATE, ddm \ "profile" \ "available", DateTypeElement toYearMonthDayFormat)
 
       addPrimitiveFieldSingleValue(citationFields, DATE_OF_DEPOSIT, optDateOfDeposit)

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Publisher.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Publisher.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2020 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.dd2d.mapping
+
+import scala.xml.{ Elem, Node }
+
+object Publisher extends BlockCitation {
+
+  def toDistributorValueObject(node: Node): JsonObject = {
+    val m = FieldMap()
+    m.addPrimitiveField(DISTRIBUTOR_NAME, node.text)
+    m.addPrimitiveField(DISTRIBUTOR_URL, "")
+    m.addPrimitiveField(DISTRIBUTOR_LOGO_URL, "")
+    m.addPrimitiveField(DISTRIBUTOR_ABBREVIATION, "")
+    m.addPrimitiveField(DISTRIBUTOR_AFFILIATION, "")
+    m.toJsonObject
+  }
+}


### PR DESCRIPTION
Fixes DD-615

# Description of changes
Adds mapping from `publisher` field to `distributor`.

# How to test
Import a deposit with `dcmiMetadata/publisher` filled in.


# Notify
@DANS-KNAW/dataversedans
