### PR TITLE
NO JIRA. Solve 'cannot edit metadata on replaced file'

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetCreator.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetCreator.scala
@@ -38,7 +38,7 @@ class DatasetCreator(deposit: Deposit,
                      optMigrationInfoService: Option[MigrationInfo]) extends DatasetEditor(instance, optFileExclusionPattern) with DebugEnhancedLogging {
   trace(deposit)
 
-  override def performEdit(): Try[PersistendId] = {
+  override def performEdit(): Try[PersistentId] = {
     {
       for {
         // autoPublish is false, because it seems there is a bug with it in Dataverse (most of the time?)
@@ -84,7 +84,7 @@ class DatasetCreator(deposit: Deposit,
     response.data.map(_.persistentId)
   }
 
-  private def embargoFiles(persistentId: PersistendId, dateAvailable: Date): Try[Unit] = {
+  private def embargoFiles(persistentId: PersistentId, dateAvailable: Date): Try[Unit] = {
     logger.info(s"Putting embargo on files until: $dateAvailable")
     for {
       files <- getFilesToEmbargo(persistentId)

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetEditor.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetEditor.scala
@@ -105,7 +105,12 @@ abstract class DatasetEditor(instance: DataverseInstance, optFileExclusionPatter
 
   protected def updateFileMetadata(databaseIdToFileInfo: Map[Int, FileMeta]): Try[Unit] = {
     trace(databaseIdToFileInfo)
-    databaseIdToFileInfo.map { case (id, fileMeta) => instance.file(id).updateMetadata(fileMeta) }.collectResults.map(_ => ())
+    databaseIdToFileInfo.map { case (id, fileMeta) => {
+      val r = instance.file(id).updateMetadata(fileMeta)
+      debug(s"id = $id, result = $r")
+      r
+    }
+    }.collectResults.map(_ => ())
   }
 
   protected def configureEnableAccessRequests(deposit: Deposit, persistendId: PersistendId, canEnable: Boolean): Try[Unit] = {
@@ -138,7 +143,7 @@ abstract class DatasetEditor(instance: DataverseInstance, optFileExclusionPatter
       r <- instance.dataset(persistendId).listFiles()
       files <- r.data
       filesToEmbargo = files.filter(f => f.directoryLabel.getOrElse("") != "easy-migration")
-    } yield  filesToEmbargo
+    } yield filesToEmbargo
   }
 
   protected def isEmbargo(date: Date): Boolean = {

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetEditor.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetEditor.scala
@@ -28,13 +28,14 @@ import java.net.URI
 import java.nio.file.{ Path, Paths }
 import java.util.Date
 import java.util.regex.Pattern
+import scala.collection.mutable
 import scala.util.{ Failure, Success, Try }
 
 /**
  * Object that edits a dataset, a new draft.
  */
 abstract class DatasetEditor(instance: DataverseInstance, optFileExclusionPattern: Option[Pattern]) extends DebugEnhancedLogging {
-  type PersistendId = String
+  type PersistentId = String
   type DatasetId = Int
 
   /**
@@ -42,18 +43,18 @@ abstract class DatasetEditor(instance: DataverseInstance, optFileExclusionPatter
    *
    * @return the persistentId of the dataset created or modified
    */
-  def performEdit(): Try[PersistendId]
+  def performEdit(): Try[PersistentId]
 
-  protected def addFiles(persistentId: String, files: List[FileInfo], prestagedFiles: Set[BasicFileMeta] = Set.empty): Try[Map[Int, FileInfo]] = {
+  protected def addFiles(persistentId: String, files: List[FileInfo], prestagedFiles: Set[BasicFileMeta] = Set.empty): Try[Map[Int, FileInfo]] = Try {
     trace(persistentId, files)
-    files
-      .map(f => {
-        debug(s"Adding file, directoryLabel = ${ f.metadata.directoryLabel }, label = ${ f.metadata.label }")
-        for {
-          id <- addFile(persistentId, f, prestagedFiles)
-          _ <- instance.dataset(persistentId).awaitUnlock()
-        } yield (id -> f)
-      }).collectResults.map(_.toMap)
+    val result = mutable.Map[Int, FileInfo]()
+    for (f <- files) {
+      debug(s"Adding file, directoryLabel = ${ f.metadata.directoryLabel }, label = ${ f.metadata.label }")
+      val id = addFile(persistentId, f, prestagedFiles).get
+      instance.dataset(persistentId).awaitUnlock().unsafeGetOrThrow
+      result(id) = f
+    }
+    result.toMap
   }
 
   private def addFile(doi: String, fileInfo: FileInfo, prestagedFiles: Set[BasicFileMeta]): Try[Int] = {
@@ -113,7 +114,7 @@ abstract class DatasetEditor(instance: DataverseInstance, optFileExclusionPatter
     }.collectResults.map(_ => ())
   }
 
-  protected def configureEnableAccessRequests(deposit: Deposit, persistendId: PersistendId, canEnable: Boolean): Try[Unit] = {
+  protected def configureEnableAccessRequests(deposit: Deposit, persistendId: PersistentId, canEnable: Boolean): Try[Unit] = {
     for {
       ddm <- deposit.tryDdm
       files <- deposit.tryFilesXml
@@ -138,7 +139,7 @@ abstract class DatasetEditor(instance: DataverseInstance, optFileExclusionPatter
     } yield ()
   }
 
-  protected def getFilesToEmbargo(persistendId: PersistendId): Try[List[FileMeta]] = {
+  protected def getFilesToEmbargo(persistendId: PersistentId): Try[List[FileMeta]] = {
     for {
       r <- instance.dataset(persistendId).listFiles()
       files <- r.data
@@ -150,7 +151,7 @@ abstract class DatasetEditor(instance: DataverseInstance, optFileExclusionPatter
     date.compareTo(new Date()) > 0
   }
 
-  protected def embargoFiles(persistendId: PersistendId, dateAvailable: Date, fileIds: List[Int]): Try[Unit] = {
+  protected def embargoFiles(persistendId: PersistentId, dateAvailable: Date, fileIds: List[Int]): Try[Unit] = {
     trace(persistendId, fileIds)
     instance.dataset(persistendId).setEmbargo(Embargo(dateAvailableFormat.format(dateAvailable), "", fileIds)).map(_ => ())
   }
@@ -168,7 +169,7 @@ abstract class DatasetEditor(instance: DataverseInstance, optFileExclusionPatter
     }
   }
 
-  private def deleteDraft(persistentId: PersistendId): Try[Unit] = {
+  private def deleteDraft(persistentId: PersistentId): Try[Unit] = {
     for {
       r <- instance.dataset(persistentId).deleteDraft()
       _ = logger.info(s"DRAFT deleted")

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetUpdater.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DatasetUpdater.scala
@@ -41,7 +41,7 @@ class DatasetUpdater(deposit: Deposit,
                      optMigrationInfoService: Option[MigrationInfo]) extends DatasetEditor(instance, optFileExclusionPattern) with DebugEnhancedLogging {
   trace(deposit)
 
-  override def performEdit(): Try[PersistendId] = {
+  override def performEdit(): Try[PersistentId] = {
     {
       for {
         doi <- if (isMigration) Try { deposit.dataversePid }


### PR DESCRIPTION
Fixes NO JIRA

Created fix together with @lindareijnhoudt 

# Description of changes
This should resolve the problem 'cannot edit metadata on replaced file'  that occurred in a handful of cases during the demo import this week. The problem was caused by the following situation:

* Version 1 of the dataset contained a file A
* The update deposit resulted in a renaming of A to B (i.e. the checksum of a file B was equal to that of A)
* The update deposit also contained a file A (with a different checksum than A in version 1), thus triggering a replacement of A with new content.

The move action (second bullet) is implemented as a metadata update on the file. However this file had just been replaced as a result of the replace action (third bullet). Dataverse correctly does not allow you to modify the metadata of a file that is not the "head" of a file version history. 

The chosen solution is to regard the move action as primary. Once a file is moved/renamed, the path that it used to occupy is now available for a new file. In the scenario above the third bullet is now regarded as a file addition. In other words in the update the old file A is renamed to B and a new file A is added. The file history of A therefore has no replacement event anymore.

Also resolves a similar problem: a file was renamed/moved to a path that was already present in the old version.

Also makes `addFiles` fail fast. If one file fails to be added it doesn't make sense to sit out the whole deposit, especially if all the files are failing due to a time out, when Dataverse is getting overwhelmed.

# How to test
Create the situation described above and import it into Dataverse.


# Notify
@DANS-KNAW/dataversedans
