### PR TITLE
DD-730. Don't migrate 'date submitted'

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositToDvDatasetMetadataMapper.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositToDvDatasetMetadataMapper.scala
@@ -86,7 +86,6 @@ class DepositToDvDatasetMetadataMapper(deduplicate: Boolean,
         (ddm \ "dcmiMetadata" \ "date") ++
         (ddm \ "dcmiMetadata" \ "dateAccepted") ++
         (ddm \ "dcmiMetadata" \ "dateCopyrighted ") ++
-        (ddm \ "dcmiMetadata" \ "dateSubmitted") ++
         (ddm \ "dcmiMetadata" \ "modified") ++
         (ddm \ "dcmiMetadata" \ "issued") ++
         (ddm \ "dcmiMetadata" \ "valid") ++


### PR DESCRIPTION
Fixes DD-730

# Description of changes
Remove `dateSubmitted` from the list of fields to be migrated to a description element.

# How to test
Migrate a dataset with "date submitted" filled in (in the form).


# Notify
@DANS-KNAW/dataversedans
