### PR TITLE
DD-748 dd-dans-deposit-to-dataverse: look up existing DOI through Is-Version-Of instead of deposit.dataversePid

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/Deposit.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/Deposit.scala
@@ -25,7 +25,6 @@ import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.configuration.PropertiesConfiguration
 
 import java.nio.file.{ Path, Paths }
-import java.text.SimpleDateFormat
 import java.util.Date
 import scala.collection.JavaConverters.{ asScalaSetConverter, mapAsScalaMapConverter }
 import scala.util.{ Failure, Try }
@@ -155,12 +154,18 @@ case class Deposit(dir: File) extends DebugEnhancedLogging {
     } yield dateAvailableFormat.parse(dateAvailable)
   }
 
-
   def isUpdate: Try[Boolean] = {
     for {
       bag <- tryBag
       isVersionOf = bag.getMetadata.get("Is-Version-Of")
     } yield isVersionOf != null && isVersionOf.size() > 0
+  }
+
+  def getIsVersionOf: Try[String] = {
+    for {
+      bag <- tryBag
+      isVersionOf = bag.getMetadata.get("Is-Version-Of").get(0)
+    } yield isVersionOf
   }
 
   def getPathToFileInfo: Try[Map[Path, FileInfo]] = {


### PR DESCRIPTION
Fixes DD-748

# Description of changes
* Look up target of update by `Is-Version-Of`. This should be the value of `dansBagId` for one of the previous dataset versions. Typically, the first dataset version should be used, but since they all have the same DOI it doesn't really matter.

# How to test
Import a version-sequence, preferably in a dataverse that already has some datasets.


# Notify
@DANS-KNAW/dataversedans
