### PR TITLE
DD-717: Rights holder is not deduplicated in specific cases

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/DcxDaiAuthor.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/DcxDaiAuthor.scala
@@ -87,7 +87,7 @@ object DcxDaiAuthor extends Contributor with BlockCitation {
 
   def toRightsHolder(node: Node): Option[String] = {
     val author = parseAuthor(node)
-    Option(formatName(author))
+    Option(formatRightsHolder(author))
   }
 
   def isRightsHolder(node: Node): Boolean = {
@@ -100,6 +100,18 @@ object DcxDaiAuthor extends Contributor with BlockCitation {
       author.insertions.getOrElse(""),
       author.surname.getOrElse(""))
       .mkString(" ").trim().replaceAll("\\s+", " ")
+  }
+
+  private def formatRightsHolder(rightsHolder: Author): String = {
+    if (rightsHolder.surname.isEmpty)
+      rightsHolder.organization.getOrElse("")
+    else
+      List(rightsHolder.titles.getOrElse(""),
+        rightsHolder.initials.getOrElse(""),
+        rightsHolder.insertions.getOrElse(""),
+        rightsHolder.surname.getOrElse(""),
+        rightsHolder.organization.map(o => s"($o)").getOrElse(""))
+        .mkString(" ").trim().replaceAll("\\s+", " ")
   }
 
   private def addIdentifier(m: FieldMap, scheme: String, value: String): Unit = {

--- a/src/test/scala/nl.knaw.dans.easy.dd2d/mapping/DcxDaiAuthorSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.dd2d/mapping/DcxDaiAuthorSpec.scala
@@ -74,4 +74,31 @@ class DcxDaiAuthorSpec extends TestSupportFixture with BlockCitation {
     findString(result, s"$CONTRIBUTOR_NAME.value") shouldBe "Anti-Vampire League"
     findString(result, s"$CONTRIBUTOR_TYPE.value") shouldBe "Other"
   }
+
+  "toRightsHolder" should "create rights holder with organization in brackets" in {
+    val author =
+      <dcx-dai:author>
+        <dcx-dai:titles>Dr</dcx-dai:titles>
+        <dcx-dai:initials>A</dcx-dai:initials>
+        <dcx-dai:insertions>van</dcx-dai:insertions>
+        <dcx-dai:surname>Helsing</dcx-dai:surname>
+        <dcx-dai:role>ProjectManager</dcx-dai:role>
+        <dcx-dai:organization>
+          <dcx-dai:name xml:lang="en">Anti-Vampire League</dcx-dai:name>
+        </dcx-dai:organization>
+      </dcx-dai:author>
+    val result = DcxDaiAuthor.toRightsHolder(author).get
+    result shouldBe "Dr A van Helsing (Anti-Vampire League)"
+  }
+
+  it should "create rights holder with organization without brackets when no surname is given" in {
+    val author =
+      <dcx-dai:author>
+        <dcx-dai:organization>
+          <dcx-dai:name xml:lang="en">Anti-Vampire League</dcx-dai:name>
+        </dcx-dai:organization>
+      </dcx-dai:author>
+    val result = DcxDaiAuthor.toRightsHolder(author).get
+    result shouldBe "Anti-Vampire League"
+  }
 }


### PR DESCRIPTION
Fixes DD-717

# Description of changes
when parsing `rightsHolder` from `dcx-author`, `titles` and `organization` are included 

# How to test


# Related PRs 
(Add links)
* 

# Notify
@DANS-KNAW/dataversedans
