### PR TITLE
No JIRA. Provide a fall-back for the getFirstChangeToState with lastStateChange

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Amd.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/Amd.scala
@@ -31,7 +31,7 @@ object Amd {
       .filter(sc => (sc \ "toState").text == state)
       .toList
       .map(_ \ "changeDate")
-      .map(_.head) // There can only be one changeDate per change
+      .map(_.headOption.getOrElse((amd \ "lastStateChange").head))
       .map(DateTypeElement.toYearMonthDayFormat)
       .map(_.get)
       .sorted


### PR DESCRIPTION
This is necessary because SWORD2-deposited datasets don't have a state change history and our code tries to find the first state change to PUBLISHED in order to determine the publication date for migrated datasets.

