### PR TITLE
DD-790

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositToDvDatasetMetadataMapper.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositToDvDatasetMetadataMapper.scala
@@ -96,6 +96,7 @@ class DepositToDvDatasetMetadataMapper(deduplicate: Boolean,
       addCvFieldMultipleValues(citationFields, SUBJECT, ddm \ "profile" \ "audience", Audience toCitationBlockSubject)
       addCompoundFieldMultipleValues(citationFields, KEYWORD, (ddm \ "dcmiMetadata" \ "subject").filter(Subject hasNoCvAttributes), Subject toKeyWordValue)
       addCompoundFieldMultipleValues(citationFields, KEYWORD, (ddm \ "dcmiMetadata" \ "language").filterNot(Language isIsoLanguage), Language toKeywordValue)
+      addCompoundFieldMultipleValues(citationFields, PUBLICATION, (ddm \ "dcmiMetadata" \ "identifier").filter(Identifier isRelatedPublication), Identifier toRelatedPublicationValue)
       addCvFieldMultipleValues(citationFields, LANGUAGE, ddm \ "dcmiMetadata" \ "language", Language.toCitationBlockLanguage(iso1ToDataverseLanguage, iso2ToDataverseLanguage))
       addPrimitiveFieldSingleValue(citationFields, PRODUCTION_DATE, ddm \ "profile" \ "created", DateTypeElement toYearMonthDayFormat)
 
@@ -115,6 +116,7 @@ class DepositToDvDatasetMetadataMapper(deduplicate: Boolean,
         case node if node.label == "contributorDetails" && (node \ "organization").nonEmpty =>
           (node \ "organization").filter(DcxDaiOrganization inAnyOfRoles(List("Funder"))).foreach(organization => addCompoundFieldMultipleValues(citationFields, GRANT_NUMBER, organization, DcxDaiOrganization toGrantNumberValueObject))
       }
+      addCompoundFieldMultipleValues(citationFields, GRANT_NUMBER, (ddm \ "dcmiMetadata" \ "identifier").filter(Identifier isNwoGrantNumber), Identifier toNwoGrantNumberValue)
 
       addCompoundFieldMultipleValues(citationFields, DISTRIBUTOR, ddm \ "dcmiMetadata" \ "publisher", Publisher toDistributorValueObject)
       addPrimitiveFieldSingleValue(citationFields, DISTRIBUTION_DATE, ddm \ "profile" \ "available", DateTypeElement toYearMonthDayFormat)
@@ -123,9 +125,6 @@ class DepositToDvDatasetMetadataMapper(deduplicate: Boolean,
       // TODO: what to set dateOfDeposit to for SWORD or multi-deposits? Take from deposit.properties?
 
       addPrimitiveFieldMultipleValues(citationFields, DATA_SOURCES, ddm \ "dcmiMetadata" \ "source")
-
-      addCompoundFieldMultipleValues(citationFields, PUBLICATION, (ddm \ "dcmiMetadata" \ "identifier").filter(Identifier isRelatedPublication), Identifier toRelatedPublicationValue)
-      addCompoundFieldMultipleValues(citationFields, GRANT_NUMBER, (ddm \ "dcmiMetadata" \ "identifier").filter(Identifier isNwoGrantNumber), Identifier toNwoGrantNumberValue)
     }
     else {
       throw new IllegalStateException("Metadatablock citation should always be active")

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositToDvDatasetMetadataMapper.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositToDvDatasetMetadataMapper.scala
@@ -103,9 +103,17 @@ class DepositToDvDatasetMetadataMapper(deduplicate: Boolean,
       val contributors = ddm \ "dcmiMetadata" \ "contributorDetails"
       contributors.foreach {
         case node if node.label == "contributorDetails" && (node \ "author").nonEmpty =>
-          (node \ "author").filterNot(DcxDaiAuthor isRightsHolder).foreach(author => addCompoundFieldMultipleValues(citationFields, CONTRIBUTOR, author, DcxDaiAuthor toContributorValueObject))
+          (node \ "author").filterNot(DcxDaiAuthor inAnyOfRoles(List("RightsHolder", "Funder"))).foreach(author => addCompoundFieldMultipleValues(citationFields, CONTRIBUTOR, author, DcxDaiAuthor toContributorValueObject))
         case node if node.label == "contributorDetails" && (node \ "organization").nonEmpty =>
-          (node \ "organization").filterNot(DcxDaiOrganization isRightsHolder).foreach(organization => addCompoundFieldMultipleValues(citationFields, CONTRIBUTOR, organization, DcxDaiOrganization toContributorValueObject))
+          (node \ "organization").filterNot(DcxDaiOrganization inAnyOfRoles(List("RightsHolder", "Funder"))).foreach(organization => addCompoundFieldMultipleValues(citationFields, CONTRIBUTOR, organization, DcxDaiOrganization toContributorValueObject))
+      }
+
+      // Add contributors with role Funder as Grant Number with only an agency subfield
+      contributors.foreach {
+        case node if node.label == "contributorDetails" && (node \ "author").nonEmpty =>
+          (node \ "author").filter(DcxDaiAuthor inAnyOfRoles(List("Funder"))).foreach(author => addCompoundFieldMultipleValues(citationFields, GRANT_NUMBER, author, DcxDaiAuthor toGrantNumberValueObject))
+        case node if node.label == "contributorDetails" && (node \ "organization").nonEmpty =>
+          (node \ "organization").filter(DcxDaiOrganization inAnyOfRoles(List("Funder"))).foreach(organization => addCompoundFieldMultipleValues(citationFields, GRANT_NUMBER, organization, DcxDaiOrganization toGrantNumberValueObject))
       }
 
       addCompoundFieldMultipleValues(citationFields, DISTRIBUTOR, ddm \ "dcmiMetadata" \ "publisher", Publisher toDistributorValueObject)

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/DcxDaiAuthor.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/DcxDaiAuthor.scala
@@ -95,6 +95,19 @@ object DcxDaiAuthor extends Contributor with BlockCitation {
     author.role.contains("RightsHolder")
   }
 
+  def inAnyOfRoles(roles: List[String])(node: Node): Boolean = {
+    val author = parseAuthor(node)
+    roles.exists(author.role.contains)
+  }
+
+  def toGrantNumberValueObject(node: Node): JsonObject = {
+    val m = FieldMap()
+    val author = parseAuthor(node)
+    m.addPrimitiveField(GRANT_NUMBER_AGENCY, formatRightsHolder(author))
+    m.addPrimitiveField(GRANT_NUMBER_VALUE, "")
+    m.toJsonObject
+  }
+
   private def formatName(author: Author): String = {
     List(author.initials.getOrElse(""),
       author.insertions.getOrElse(""),

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/DcxDaiOrganization.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/DcxDaiOrganization.scala
@@ -15,6 +15,8 @@
  */
 package nl.knaw.dans.easy.dd2d.mapping
 
+import nl.knaw.dans.easy.dd2d.mapping.DcxDaiAuthor.{ GRANT_NUMBER_AGENCY, GRANT_NUMBER_VALUE, formatRightsHolder, parseAuthor }
+
 import scala.xml.Node
 
 object DcxDaiOrganization extends Contributor with BlockCitation {
@@ -45,6 +47,19 @@ object DcxDaiOrganization extends Contributor with BlockCitation {
   def isRightsHolder(node: Node): Boolean = {
     val organization = parseOrganization(node)
     organization.role.contains("RightsHolder")
+  }
+
+  def inAnyOfRoles(roles: List[String])(node: Node): Boolean = {
+    val author = parseOrganization(node)
+    roles.exists(author.role.contains)
+  }
+
+  def toGrantNumberValueObject(node: Node): JsonObject = {
+    val m = FieldMap()
+    val organization = parseOrganization(node)
+    m.addPrimitiveField(GRANT_NUMBER_AGENCY, organization.name.getOrElse(""))
+    m.addPrimitiveField(GRANT_NUMBER_VALUE, "")
+    m.toJsonObject
   }
 
   def toRightsHolder(node: Node): Option[String] = {


### PR DESCRIPTION
Fixes DD-790

# Description of changes
* Filtered the "Funder" contributors from the mapping to the Dataverse contributor field.
* Added a Grant Information field for each "Funder" contributor, formatting the information the same as for a rightsholder.

# How to test
* Build and deploy `dd-dans-deposit-to-dataverse`.
* Create a deposit with a contributor with role "Funder"
* Import it with `--skip-validation`. This is currently necessary because "Funder" is not a valid DataCite role. See comments in DD-790

# Related PRs 
* 

# Notify
@DANS-KNAW/dataversedans
