### PR TITLE
DD-398. Added support for abr temporal as specified by PAN

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/AbrScheme.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/AbrScheme.scala
@@ -21,6 +21,9 @@ trait AbrScheme {
   val SCHEME_ABR_OLD = "Archeologisch Basis Register"
   val SCHEME_URI_ABR_OLD = "https://data.cultureelerfgoed.nl/term/id/rn/a4a7933c-e096-4bcf-a921-4f70a78749fe"
 
+  val SCHEME_ABR_PLUS = "Archeologisch Basis Register"
+  val SCHEME_URI_ABR_PLUS = "https://data.cultureelerfgoed.nl/term/id/abr/b6df7840-67bf-48bd-aa56-7ee39435d2ed"
+
   val SCHEME_ABR_COMPLEX = "ABR Complextypen"
   val SCHEME_URI_ABR_COMPLEX = "https://data.cultureelerfgoed.nl/term/id/abr/e9546020-4b28-4819-b0c2-29e7c864c5c0"
 

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/TemporalAbr.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/TemporalAbr.scala
@@ -33,7 +33,12 @@ object TemporalAbr extends BlockArchaeologySpecific with AbrScheme with DebugEnh
    */
   def isAbrPeriod(node: Node): Boolean = {
     // TODO: also take attribute namespace into account (should be ddm)
-    // TODO: correct the scheme: should be 'ABR Period' ??
-    node.label == "temporal" && hasAttribute(node, "subjectScheme", SCHEME_ABR_PERIOD) && hasAttribute(node, "schemeURI", SCHEME_URI_ABR_PERIOD)
+    node.label == "temporal" &&
+      /*
+       * Either specify exactly the subtree for periods or just the general ABR+ thesaurus. The latter is supported for PAN. Since the element
+       * is "temporal" it is clear enough that we are dealing with a period anyway.
+       */
+      (hasAttribute(node, "subjectScheme", SCHEME_ABR_PERIOD) && hasAttribute(node, "schemeURI", SCHEME_URI_ABR_PERIOD) ||
+        hasAttribute(node, "subjectScheme", SCHEME_ABR_PLUS) && hasAttribute(node, "schemeURI", SCHEME_URI_ABR_PLUS))
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.dd2d/mapping/TemporalAbrSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.dd2d/mapping/TemporalAbrSpec.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2020 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.dd2d.mapping
+
+import nl.knaw.dans.easy.dd2d.TestSupportFixture
+
+class TemporalAbrSpec extends TestSupportFixture with BlockArchaeologySpecific with AbrScheme {
+
+  "isAbrPeriod" should "return true if schemeURI, subjectScheme for ABR Periods is used" in {
+    val xml =  <ddm:temporal
+      schemeURI={ SCHEME_URI_ABR_PERIOD }
+      subjectScheme={ SCHEME_ABR_PERIOD }
+      valueURI="https://data.cultureelerfgoed.nl/term/id/abr/c6858173-5ca2-4319-b242-f828ec53d52d" xml:lang="nl">Nieuwe Tijd</ddm:temporal>
+
+    TemporalAbr.isAbrPeriod(xml) shouldBe true
+  }
+
+  it should "return false if schemeURI does not match" in {
+    val xml =  <ddm:temporal
+      schemeURI="https://data.cultureelerfgoed.nl/term/id/rn/NO-MATCH"
+      subjectScheme={ SCHEME_ABR_PERIOD }
+      valueURI="https://data.cultureelerfgoed.nl/term/id/abr/c6858173-5ca2-4319-b242-f828ec53d52d" xml:lang="nl">Nieuwe Tijd</ddm:temporal>
+
+    TemporalAbr.isAbrPeriod(xml) shouldBe false
+  }
+
+  it should "return false if subjectScheme does not match" in {
+    val xml =  <ddm:temporal
+      schemeURI={ SCHEME_URI_ABR_PERIOD }
+      subjectScheme="NO MATCH"
+      valueURI="https://data.cultureelerfgoed.nl/term/id/abr/c6858173-5ca2-4319-b242-f828ec53d52d" xml:lang="nl">Nieuwe Tijd</ddm:temporal>
+
+    TemporalAbr.isAbrPeriod(xml) shouldBe false
+  }
+
+  it should "return true if schemeURI, subjectScheme for ABR+ is used" in {
+    val xml =  <ddm:temporal
+      schemeURI={ SCHEME_URI_ABR_PLUS }
+      subjectScheme={ SCHEME_ABR_PLUS }
+      valueURI="https://data.cultureelerfgoed.nl/term/id/abr/c6858173-5ca2-4319-b242-f828ec53d52d" xml:lang="nl">Nieuwe Tijd</ddm:temporal>
+
+    TemporalAbr.isAbrPeriod(xml) shouldBe true
+  }
+
+  it should "return false if schemeURI of ABR+ does not match" in {
+    val xml =  <ddm:temporal
+      schemeURI="https://data.cultureelerfgoed.nl/term/id/rn/NO-MATCH"
+      subjectScheme={ SCHEME_ABR_PLUS }
+      valueURI="https://data.cultureelerfgoed.nl/term/id/abr/c6858173-5ca2-4319-b242-f828ec53d52d" xml:lang="nl">Nieuwe Tijd</ddm:temporal>
+
+    TemporalAbr.isAbrPeriod(xml) shouldBe false
+  }
+
+  it should "return false if subjectScheme of ABR+ does not match" in {
+    val xml =  <ddm:temporal
+      schemeURI={ SCHEME_URI_ABR_PLUS }
+      subjectScheme="NO MATCH"
+      valueURI="https://data.cultureelerfgoed.nl/term/id/abr/c6858173-5ca2-4319-b242-f828ec53d52d" xml:lang="nl">Nieuwe Tijd</ddm:temporal>
+
+    TemporalAbr.isAbrPeriod(xml) shouldBe false
+  }
+
+}


### PR DESCRIPTION
Fixes DD-398

# Description of changes
* Extended the method that recognizes an ABR period value in a `temporal` element to include those that use as `schemeURI` the general ABR+ uri and as  `subjectScheme` the corresponding name.

# Notify
@DANS-KNAW/dataversedans
