### PR TITLE
DD-818 Implemented mapping of datesOfCollection to dateOfCollection field

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.dd2d/DepositToDvDatasetMetadataMapper.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/DepositToDvDatasetMetadataMapper.scala
@@ -116,6 +116,8 @@ class DepositToDvDatasetMetadataMapper(deduplicate: Boolean,
       addPrimitiveFieldSingleValue(citationFields, DATE_OF_DEPOSIT, optDateOfDeposit)
       // TODO: what to set dateOfDeposit to for SWORD or multi-deposits? Take from deposit.properties?
 
+      addCompoundFieldMultipleValues(citationFields, DATE_OF_COLLECTION, ddm \ "dcmiMetadata" \ "datesOfCollection", DatesOfCollection.toDateOfCollectionValue)
+
       addPrimitiveFieldMultipleValues(citationFields, DATA_SOURCES, ddm \ "dcmiMetadata" \ "source")
 
       addCompoundFieldMultipleValues(citationFields, PUBLICATION, (ddm \ "dcmiMetadata" \ "identifier").filter(Identifier isRelatedPublication), Identifier toRelatedPublicationValue)

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/DatesOfCollection.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/DatesOfCollection.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2020 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.dd2d.mapping
+
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+
+import scala.xml.Node
+
+object DatesOfCollection extends BlockCitation with DebugEnhancedLogging {
+  private val rangePattern = """^(.*)/(.*)$""".r(DATE_OF_COLLECTION_START, DATE_OF_COLLECTION_END)
+
+  def toDateOfCollectionValue(node: Node): JsonObject = {
+    val m = FieldMap()
+    val matchIterator = rangePattern.findAllIn(node.text)
+    m.addPrimitiveField(DATE_OF_COLLECTION_START, matchIterator.group(DATE_OF_COLLECTION_START))
+    m.addPrimitiveField(DATE_OF_COLLECTION_END, matchIterator.group(DATE_OF_COLLECTION_END))
+    m.toJsonObject
+  }
+}

--- a/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/DatesOfCollection.scala
+++ b/src/main/scala/nl.knaw.dans.easy.dd2d/mapping/DatesOfCollection.scala
@@ -24,7 +24,7 @@ object DatesOfCollection extends BlockCitation with DebugEnhancedLogging {
 
   def toDateOfCollectionValue(node: Node): JsonObject = {
     val m = FieldMap()
-    val matchIterator = rangePattern.findAllIn(node.text)
+    val matchIterator = rangePattern.findAllIn(node.text.trim)
     m.addPrimitiveField(DATE_OF_COLLECTION_START, matchIterator.group(DATE_OF_COLLECTION_START))
     m.addPrimitiveField(DATE_OF_COLLECTION_END, matchIterator.group(DATE_OF_COLLECTION_END))
     m.toJsonObject

--- a/src/test/scala/nl.knaw.dans.easy.dd2d/mapping/DatesOfCollectionSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.dd2d/mapping/DatesOfCollectionSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2020 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.dd2d.mapping
+
+import nl.knaw.dans.easy.dd2d.TestSupportFixture
+import org.json4s.native.Serialization
+import org.json4s.{ DefaultFormats, Formats }
+
+class DatesOfCollectionSpec extends TestSupportFixture with BlockCitation {
+  private implicit val jsonFormats: Formats = DefaultFormats
+
+  "toDateOfCollectionValue" should "split correctly formatted date range in start and end subfields" in {
+    val datesOfCollection = <ddm:datesOfCollection>2022-01-01/2022-02-01</ddm:datesOfCollection>
+    val result = Serialization.writePretty(DatesOfCollection.toDateOfCollectionValue(datesOfCollection))
+    findString(result, s"$DATE_OF_COLLECTION_START.value") shouldBe "2022-01-01"
+    findString(result, s"$DATE_OF_COLLECTION_END.value") shouldBe "2022-02-01"
+  }
+
+  it should "handle ranges without start" in {
+    val datesOfCollection = <ddm:datesOfCollection>/2022-02-01</ddm:datesOfCollection>
+    val result = Serialization.writePretty(DatesOfCollection.toDateOfCollectionValue(datesOfCollection))
+    findString(result, s"$DATE_OF_COLLECTION_START.value") shouldBe ""
+    findString(result, s"$DATE_OF_COLLECTION_END.value") shouldBe "2022-02-01"
+  }
+
+  it should "handle ranges without end" in {
+    val datesOfCollection = <ddm:datesOfCollection>2022-01-01/</ddm:datesOfCollection>
+    val result = Serialization.writePretty(DatesOfCollection.toDateOfCollectionValue(datesOfCollection))
+    findString(result, s"$DATE_OF_COLLECTION_START.value") shouldBe "2022-01-01"
+    findString(result, s"$DATE_OF_COLLECTION_END.value") shouldBe ""
+  }
+
+}

--- a/src/test/scala/nl.knaw.dans.easy.dd2d/mapping/DatesOfCollectionSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.dd2d/mapping/DatesOfCollectionSpec.scala
@@ -43,4 +43,13 @@ class DatesOfCollectionSpec extends TestSupportFixture with BlockCitation {
     findString(result, s"$DATE_OF_COLLECTION_END.value") shouldBe ""
   }
 
+  it should "handle whitespace at beginnen and end of text" in {
+    val datesOfCollection = <ddm:datesOfCollection>
+      2022-01-01/2022-02-01
+    </ddm:datesOfCollection>
+    val result = Serialization.writePretty(DatesOfCollection.toDateOfCollectionValue(datesOfCollection))
+    findString(result, s"$DATE_OF_COLLECTION_START.value") shouldBe "2022-01-01"
+    findString(result, s"$DATE_OF_COLLECTION_END.value") shouldBe "2022-02-01"
+  }
+
 }


### PR DESCRIPTION
Fixes DD-818

# Description of changes
* Map `ddm:datesOfCollection` text value in the format `start/end` to `dateOfCollection` field.
* Assumes that the format has been checked by `easy-validate-dans-bag`.
* I have not verified if Dataverse handles year-month or year-only dates well.

# Notify
@DANS-KNAW/dataversedans
